### PR TITLE
Update test job name and condition

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,15 @@
-name: Check Markdown and Examples
-on: [push, pull_request]
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
 jobs:
-  deploy:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v2


### PR DESCRIPTION
This updates the test job name to be `test` instead of `deploy`.  The workflow only runs on merge request against main and on pushes to main (instead of running on pushes to every branch).