### PR TITLE
Landsat + MODIS + Sentinel item types

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,18 @@ The following specifications are relevant here:
 
 | Field Name     | PSOrthoTile | PSScene | REOrthoTile | REScene | SkySatCollect | SkySatScene | SkySatVideo | Landsat8L1G | M(O/Y)D09G(A/Q) | Sentinel1 | Sentinel2L1C |
 | -------------- | ----------- | ------- | ----------- | ------- | ------------- | ----------- | ----------- | ----------- | --------------- | --------- | ------------ |
-| instruments    | ✓ | ✓ |   |   |   |   |   | ✓ | ✓ |   | ✓ |
-| gsd            | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ |
-| eo:cloud_cover | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ |
-| eo:snow_cover  |   | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |
-| view:azimuth   | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |   |   |   |   |
+| instruments               | ✓ | ✓ |   |   |   |   |   | ✓ | ✓ |   | ✓ |
+| gsd                       | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ |
+| eo:cloud_cover            | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ |   | ✓ |
+| eo:snow_cover             |   | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |
+| view:azimuth              | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |   |   |   |   |
+| view:sun_azimuth          | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| view:sun_elevation        | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| sar:frequency_band        |   |   |   |   |   |   |   |   |   | ✓ |   |
+| sar:instrument_mode       |   |   |   |   |   |   |   |   |   | ✓ |   |
+| sar:observation_direction |   |   |   |   |   |   |   |   |   | ✓ |   |
+| sar:polarizations         |   |   |   |   |   |   |   |   |   | ✓ |   |
+| sar:product_type          |   |   |   |   |   |   |   |   |   | ✓ |   |
 
 #### constellation
 
@@ -237,6 +244,9 @@ The following specifications are relevant here:
 - [STAC Projection Extension](https://github.com/stac-extensions/projection) (v1.1.0 or later)
 - [STAC Raster Extension](https://github.com/stac-extensions/raster) (v1.0.0 or later)
 - [STAC Timestamps Extension](https://github.com/stac-extensions/timestamps) (v1.1.0 or later)
+
+For Sentinel1
+- [STAC SAR Extension](https://github.com/stac-extensions/sar) (v1.0.0 or later)
 
 | Field Name   | Type        | Description |
 | ------------ | ----------- | ----------- |

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The following patterns are allowed for the Planet Labs satellites:
 For non Planet Satellites:
 
 - Landsat8: `Landsat8`
-- MODIS: `Terra`
+- MODIS: `Terra` or `Aqua`
 - Sentinel: `Sentinel\w+`
 
 #### instruments

--- a/README.md
+++ b/README.md
@@ -69,20 +69,21 @@ The fields in the tables below can be used in these parts of STAC documents:
 | pl:pixel_resolution     | number  | The spatial resolution, in meters. (This is meant to be deprecated in favor of [`spatial_resolution`](https://github.com/radiantearth/stac-spec/issues/1196).) |
 | pl:publishing_stage     | string  | Stage of [publishing for an item](https://developers.planet.com/docs/apis/data/items-assets/#item-publishing-lifecycle). Allowed values: `preview`, `standard`, `finalized`. |
 | pl:quality_category     | string  | Metric for image quality. Allowed values: `standard`, `test`. |
-| pl:strip_id             | string  | **REQUIRED.** The unique identifier of the image stripe that the item came from. |
+| pl:strip_id             | string  | The unique identifier of the image stripe that the item came from. |
 
 **Additional REQUIRED fields per `pl:item_type`:**
 
-| Field Name              | PSOrthoTile | PSScene | REOrthoTile | REScene | SkySatCollect | SkySatScene | SkySatVideo |
-| ----------------------- | ----------- | ------- | ----------- | ------- | ------------- | ----------- | ----------- |
-| pl:black_fill           | ✓ |   | ✓ | ✓ |   |   |   |
-| pl:clear_percent        | ✓ | ✓ |   |   | ✓ | ✓ |   |
-| pl:grid_cell            | ✓ |   | ✓ |   |   |   |   |
-| pl:ground_control       | ✓ | ✓ | ✓ |   |   | ✓ |   |
-| pl:ground_control_ratio |   |   |   |   | ✓ |   |   |
-| pl:pixel_resolution     | ✓ | ✓ | ✓ |   | ✓ | ✓ |   |
-| pl:publishing_stage     | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |
-| pl:quality_category     | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |
+| Field Name              | PSOrthoTile | PSScene | REOrthoTile | REScene | SkySatCollect | SkySatScene | SkySatVideo | Landsat8L1G | M(O/Y)D09G(A/Q) | Sentinel1 | Sentinel2L1C |
+| ----------------------- | ----------- | ------- | ----------- | ------- | ------------- | ----------- | ----------- | ----------- | --------------- | --------- | ------------ |
+| pl:black_fill           | ✓ |   | ✓ | ✓ |   |   |   |   | ✓ | ✓ | ✓ |
+| pl:clear_percent        | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |
+| pl:grid_cell            | ✓ |   | ✓ |   |   |   |   |   |   |   |   |
+| pl:ground_control       | ✓ | ✓ | ✓ |   |   | ✓ |   |   |   |   |   |
+| pl:ground_control_ratio |   |   |   |   | ✓ |   |   |   |   |   |   |
+| pl:pixel_resolution     | ✓ | ✓ | ✓ |   | ✓ | ✓ |   | ✓ | ✓ |   | ✓ |
+| pl:publishing_stage     | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |   |   |   |   |
+| pl:quality_category     | ✓ | ✓ |   |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| pl:strip_id             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   |
 
 #### pl:item_type
 
@@ -98,6 +99,13 @@ The following values exist for the Planet Labs satellites:
   - [`SkySatCollect`](https://developers.planet.com/docs/data/skysatcollect/)
   - [`SkySatScene`](https://developers.planet.com/docs/data/skysatscene/)
   - [`SkySatVideo`](https://developers.planet.com/docs/data/skysatvideo/)
+
+The following item types don't come from Planet satellites, but have some support in Planet APIs:
+
+- [`Landsat8L1G`](https://developers.planet.com/docs/data/landsat-8/)
+- [`MOD09GA`, `MYD09GA`, `MOD09GQ`, `MYD09GQ`](https://developers.planet.com/apis/orders/product-bundles-reference/)
+- [`Sentinel1`](https://developers.planet.com/apis/orders/product-bundles-reference/)
+- [`Sentinel2L1C`](https://developers.planet.com/docs/data/sentinel2l1c/)
 
 ### Other Extensions and Specifications
 
@@ -124,13 +132,13 @@ The following specifications are relevant here:
 
 **Additional REQUIRED fields per `pl:item_type`:**
 
-| Field Name     | PSOrthoTile | PSScene | REOrthoTile | REScene | SkySatCollect | SkySatScene | SkySatVideo |
-| -------------- | ----------- | ------- | ----------- | ------- | ------------- | ----------- | ----------- |
-| instruments    | ✓ | ✓ |   |   |   |   |   |
-| gsd            | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| eo:cloud_cover | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| eo:snow_cover  |   | ✓ |   |   | ✓ | ✓ |   |
-| view:azimuth   | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |
+| Field Name     | PSOrthoTile | PSScene | REOrthoTile | REScene | SkySatCollect | SkySatScene | SkySatVideo | Landsat8L1G | M(O/Y)D09G(A/Q) | Sentinel1 | Sentinel2L1C |
+| -------------- | ----------- | ------- | ----------- | ------- | ------------- | ----------- | ----------- | ----------- | --------------- | --------- | ------------ |
+| instruments    | ✓ | ✓ |   |   |   |   |   | ✓ | ✓ |   | ✓ |
+| gsd            | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ |
+| eo:cloud_cover | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ |
+| eo:snow_cover  |   | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |
+| view:azimuth   | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |   |   |   |   |
 
 #### constellation
 
@@ -140,6 +148,11 @@ The following values exist for the Planet Labs satellites:
 - RapidEye: `rapideye`
 - SkySat: `skysat`
 
+For non Planet Satellites:
+
+- Landsat8/MODIS: `usgs`
+- Sentinel: `esa`
+
 #### platform
 
 The following patterns are allowed for the Planet Labs satellites:
@@ -148,6 +161,12 @@ The following patterns are allowed for the Planet Labs satellites:
 - RapidEye: `RapidEye-\d+` (e.g. `RapidEye-1`, `RapidEye-2`, etc.)
 - SkySat: `SSC\\d+` (e.g. `SSC1`, `SSC19`, etc.)
 
+For non Planet Satellites:
+
+- Landsat8: `Landsat8`
+- MODIS: `Terra`
+- Sentinel: `Sentinel\w+`
+
 #### instruments
 
 The following values exist for the Planet Labs satellites:
@@ -155,6 +174,13 @@ The following values exist for the Planet Labs satellites:
 - PlanetScope: `PS2` (Dove Classic), `PS2.SD` (Dove-R), `PSB.SD` (SuperDove)
 - RapidEye: n/a
 - SkySat: n/a
+  
+For non Planet Satellites:
+
+- Landsat8: `OLI_TIRS`
+- MODIS: `MODIS`
+- Sentinel1: n/a
+- Sentinel2: `MSI`
 
 Please note that the `instruments` field is always specified as an array.
 
@@ -198,6 +224,8 @@ The allowed asset types can be found here per item type:
   - [`SkySatCollect`](https://developers.planet.com/docs/data/skysatcollect/#available-asset-types)
   - [`SkySatScene`](https://developers.planet.com/docs/data/skysatscene/#available-asset-types)
   - [`SkySatVideo`](https://developers.planet.com/docs/data/skysatvideo/#available-asset-types)
+- Landsat, Sentinel, MODIS
+  - These asset types aren't documented as much on the Planet side, but can be explored [here](https://developers.planet.com/apis/orders/product-bundles-reference/) or in the schema
 
 The [JSON Schema](./json-schema/schema.json) also provides a full list of all allowed values.
 
@@ -227,11 +255,11 @@ To avoid ambiguities it is recommended to have them at the Asset-level, but both
 
 **Additional REQUIRED fields per `pl:item_type`:**
 
-| Field Name                           | PSOrthoTile | PSScene | REOrthoTile | REScene | SkySatCollect | SkySatScene | SkySatVideo |
-| ------------------------------------ | ----------- | ------- | ----------- | ------- | ------------- | ----------- | ----------- |
-| proj:epsg                            | ✓ |   | ✓ |   |   |   |   |
-| proj.shape                           | ✓ | ✓ | ✓ | ✓ |   |   |   |
-| raster:bands\[\*].spatial_resolution | ✓ | ✓ | ✓ |   | ✓ | ✓ |   |
+| Field Name                           | PSOrthoTile | PSScene | REOrthoTile | REScene | SkySatCollect | SkySatScene | SkySatVideo | Landsat8L1G | M(O/Y)D09G(A/Q) | Sentinel1 | Sentinel2L1C |
+| ------------------------------------ | ----------- | ------- | ----------- | ------- | ------------- | ----------- | ----------- | ----------- | --------------- | --------- | ------------ |
+| proj:epsg                            | ✓ |   | ✓ |   |   |   |   | ✓ |   | ✓ | ✓ |
+| proj.shape                           | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓ |   | ✓ | ✓ |
+| raster:bands\[\*].spatial_resolution | ✓ | ✓ | ✓ |   | ✓ | ✓ |   | ✓ |   |   | ✓ |
 
 *Note: These requirements are not enforced in the JSON Schema yet.*
 

--- a/examples/items/Landsat8L1G.json
+++ b/examples/items/Landsat8L1G.json
@@ -1,0 +1,189 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "LC82190652018002LGN00",
+  "properties": {
+    "updated": "2022-04-13T20:39:05Z",
+    "created": "2022-04-13T20:39:05Z",
+    "gsd": 30,
+    "constellation": "usgs",
+    "platform": "Landsat8",
+    "instruments": [
+      "OLI_TIRS"
+    ],
+    "eo:cloud_cover": 90.2,
+    "view:off_nadir": 0,
+    "view:sun_azimuth": 122.5,
+    "view:sun_elevation": 58.1,
+    "pl:collection": "2",
+    "pl:data_type": "L1TP",
+    "pl:item_type": "Landsat8L1G",
+    "pl:pixel_resolution": 30,
+    "pl:processed": "2020-09-02T11:20:42Z",
+    "pl:product_id": "LC08_L1TP_219065_20180102_20200902_02_T1",
+    "pl:quality_category": "standard",
+    "pl:usable_data": 0.686,
+    "pl:wrs_path": 219,
+    "pl:wrs_row": 65,
+    "published": "2022-04-13T20:39:05Z",
+    "proj:epsg": null,
+    "datetime": "2018-01-02T13:00:06.942405Z"
+  },
+  "geometry": {
+    "coordinates": [
+      [
+        [
+          -43.59795349975637,
+          -6.187763200391768
+        ],
+        [
+          -41.953040210223655,
+          -6.539147977116791
+        ],
+        [
+          -42.322274594050036,
+          -8.275927456292084
+        ],
+        [
+          -43.97342783396222,
+          -7.920828136404763
+        ],
+        [
+          -43.59795349975637,
+          -6.187763200391768
+        ]
+      ]
+    ],
+    "type": "Polygon"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "./Landsat8L1G_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./Landsat8L1G_collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "LC82190652018002LGN00_metadata_json": {
+      "href": "./LC82190652018002LGN00_metadata.json",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "LC82190652018002LGN00_Visual_tif": {
+      "href": "./LC82190652018002LGN00_Visual.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "pl:asset_type": "visual",
+      "pl:bundle_type": "visual",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 30.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 255.0
+          }
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 30.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 255.0
+          }
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 30.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 255.0
+          }
+        },
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 30.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 255.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Red",
+          "common_name": "red",
+          "center_wavelength": 0.655,
+          "full_width_half_max": 0.037
+        },
+        {
+          "name": "Green",
+          "common_name": "green",
+          "center_wavelength": 0.561,
+          "full_width_half_max": 0.057
+        },
+        {
+          "name": "Blue",
+          "common_name": "blue",
+          "center_wavelength": 0.482,
+          "full_width_half_max": 0.06
+        },
+        {
+          "name": "Alpha",
+          "description": "Pixel opacity (0: fully transparent; 255: fully opaque)"
+        }
+      ],
+      "proj:epsg": 32623,
+      "proj:bbox": [
+        611985.0,
+        -916815.0,
+        840615.0,
+        -683685.0
+      ],
+      "proj:shape": [
+        7771,
+        7621
+      ],
+      "proj:transform": [
+        30.0,
+        0.0,
+        611985.0,
+        0.0,
+        -30.0,
+        -683685.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data",
+        "visual"
+      ]
+    }
+  },
+  "bbox": [
+    -43.97342783396222,
+    -8.275927456292084,
+    -41.953040210223655,
+    -6.187763200391768
+  ],
+  "stac_extensions": [
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.1/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "collection": "d8416b0d-8afd-44ef-b1ea-826134555ad0: Landsat8L1G"
+}

--- a/examples/items/Landsat8L1G.json
+++ b/examples/items/Landsat8L1G.json
@@ -89,34 +89,34 @@
       "raster:bands": [
         {
           "data_type": "uint8",
-          "spatial_resolution": 30.0,
+          "spatial_resolution": 30,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 255.0
+            "minimum": 0,
+            "maximum": 255
           }
         },
         {
           "data_type": "uint8",
-          "spatial_resolution": 30.0,
+          "spatial_resolution": 30,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 255.0
+            "minimum": 0,
+            "maximum": 255
           }
         },
         {
           "data_type": "uint8",
-          "spatial_resolution": 30.0,
+          "spatial_resolution": 30,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 255.0
+            "minimum": 0,
+            "maximum": 255
           }
         },
         {
           "data_type": "uint8",
-          "spatial_resolution": 30.0,
+          "spatial_resolution": 30,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 255.0
+            "minimum": 0,
+            "maximum": 255
           }
         }
       ],
@@ -146,25 +146,25 @@
       ],
       "proj:epsg": 32623,
       "proj:bbox": [
-        611985.0,
-        -916815.0,
-        840615.0,
-        -683685.0
+        611985,
+        -916815,
+        840615,
+        -683685
       ],
       "proj:shape": [
         7771,
         7621
       ],
       "proj:transform": [
-        30.0,
-        0.0,
-        611985.0,
-        0.0,
-        -30.0,
-        -683685.0,
-        0.0,
-        0.0,
-        1.0
+        30,
+        0,
+        611985,
+        0,
+        -30,
+        -683685,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data",

--- a/examples/items/MOD09GA.json
+++ b/examples/items/MOD09GA.json
@@ -88,12 +88,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 255.0,
+          "nodata": 255,
           "data_type": "uint8",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 0.0
+            "minimum": 0,
+            "maximum": 0
           }
         }
       ],
@@ -108,12 +108,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 0.0,
+          "nodata": 0,
           "data_type": "uint8",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 1.0,
-            "maximum": 255.0
+            "minimum": 1,
+            "maximum": 255
           }
         }
       ],
@@ -128,12 +128,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 255.0,
+          "nodata": 255,
           "data_type": "uint8",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 6.0
+            "minimum": 0,
+            "maximum": 6
           }
         }
       ],
@@ -148,12 +148,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 7.0
+            "minimum": 0,
+            "maximum": 7
           }
         }
       ],
@@ -168,12 +168,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 1.0
+            "minimum": 0,
+            "maximum": 1
           }
         }
       ],
@@ -188,12 +188,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 85.0
+            "minimum": 0,
+            "maximum": 85
           }
         }
       ],
@@ -208,12 +208,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 0.0
+            "minimum": 0,
+            "maximum": 0
           }
         }
       ],
@@ -228,12 +228,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 787410671.0,
+          "nodata": 787410671,
           "data_type": "uint32",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 1073741824.0,
-            "maximum": 2016900983.0
+            "minimum": 1073741824,
+            "maximum": 2016900983
           }
         }
       ],
@@ -251,8 +251,8 @@
           "data_type": "uint8",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 255.0
+            "minimum": 0,
+            "maximum": 255
           }
         }
       ],
@@ -267,12 +267,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 65535.0,
+          "nodata": 65535,
           "data_type": "uint16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 55737.0
+            "minimum": 0,
+            "maximum": 55737
           }
         }
       ],
@@ -287,12 +287,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -32767.0,
+          "nodata": -32767,
           "data_type": "int16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": -17660.0,
-            "maximum": 17855.0
+            "minimum": -17660,
+            "maximum": 17855
           }
         }
       ],
@@ -307,12 +307,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -32767.0,
+          "nodata": -32767,
           "data_type": "int16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 3.0,
-            "maximum": 6522.0
+            "minimum": 3,
+            "maximum": 6522
           }
         }
       ],
@@ -327,12 +327,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -32767.0,
+          "nodata": -32767,
           "data_type": "int16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 13324.0,
-            "maximum": 15172.0
+            "minimum": 13324,
+            "maximum": 15172
           }
         }
       ],
@@ -347,12 +347,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -32767.0,
+          "nodata": -32767,
           "data_type": "int16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 2856.0,
-            "maximum": 4251.0
+            "minimum": 2856,
+            "maximum": 4251
           }
         }
       ],
@@ -367,12 +367,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 65535.0,
+          "nodata": 65535,
           "data_type": "uint16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 40982.0
+            "minimum": 0,
+            "maximum": 40982
           }
         }
       ],
@@ -387,12 +387,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 13958.0
+            "minimum": -100,
+            "maximum": 13958
           }
         }
       ],
@@ -416,12 +416,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 11687.0
+            "minimum": -100,
+            "maximum": 11687
           }
         }
       ],
@@ -445,12 +445,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 16000.0
+            "minimum": -100,
+            "maximum": 16000
           }
         }
       ],
@@ -474,12 +474,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 13526.0
+            "minimum": -100,
+            "maximum": 13526
           }
         }
       ],
@@ -503,12 +503,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 9974.0
+            "minimum": -100,
+            "maximum": 9974
           }
         }
       ],
@@ -531,12 +531,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 6.0,
-            "maximum": 7682.0
+            "minimum": 6,
+            "maximum": 7682
           }
         }
       ],
@@ -560,12 +560,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 5758.0
+            "minimum": -100,
+            "maximum": 5758
           }
         }
       ],
@@ -585,7 +585,7 @@
   },
   "bbox": [
     -81.1488419095665,
-    0.0,
+    0,
     -69.92175029005186,
     10.05511074506398
   ],

--- a/examples/items/MOD09GA.json
+++ b/examples/items/MOD09GA.json
@@ -1,0 +1,600 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "MOD09GA.A2023006.h10v08.061.2023009221057",
+  "properties": {
+    "updated": "2023-01-20T03:10:31Z",
+    "created": "2023-01-20T03:10:31Z",
+    "gsd": 500,
+    "constellation": "usgs",
+    "platform": "Terra",
+    "instruments": [
+      "MODIS"
+    ],
+    "eo:cloud_cover": 0,
+    "view:off_nadir": 0,
+    "view:sun_azimuth": 0,
+    "view:sun_elevation": 0,
+    "pl:black_fill": 0.07,
+    "pl:data_type": "L2GL",
+    "pl:item_type": "MOD09GA",
+    "pl:orbit_direction": "ASC",
+    "pl:pixel_resolution": 500,
+    "pl:product_generation_time": "2023-01-09T22:10:57Z",
+    "pl:product_version": "6.0.9",
+    "pl:quality_category": "standard",
+    "pl:sgrid_tile_id": "h10v08",
+    "pl:usable_data": 0.93,
+    "published": "2023-01-20T03:10:31Z",
+    "proj:epsg": null,
+    "datetime": "2023-01-06T11:59:59Z"
+  },
+  "geometry": {
+    "coordinates": [
+      [
+        [
+          -81.1488419095665,
+          10.05511074506398
+        ],
+        [
+          -71.00523667086385,
+          10.05511074506398
+        ],
+        [
+          -69.92175029005186,
+          0
+        ],
+        [
+          -79.91057176006697,
+          0
+        ],
+        [
+          -81.1488419095665,
+          10.05511074506398
+        ]
+      ]
+    ],
+    "type": "Polygon"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "./MOD09GA_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./MOD09GA_collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "MOD09GA_A2023006_h10v08_061_2023009221057_metadata_json": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057_metadata.json",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_GFLAGS_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.GFLAGS.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_gflags",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 255.0,
+          "data_type": "uint8",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 0.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_GRANULE_PNT_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.GRANULE_PNT.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_granule_pnt",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 0.0,
+          "data_type": "uint8",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 1.0,
+            "maximum": 255.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_IOBS_RES_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.IOBS_RES.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_iobs_res",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 255.0,
+          "data_type": "uint8",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 6.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_NUM_OBSERVATIONS_1KM_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.NUM_OBSERVATIONS_1KM.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_num_observations_1km",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 7.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_NUM_OBSERVATIONS_500M_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.NUM_OBSERVATIONS_500M.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_num_observations_500m",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 1.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_OBSCOV_500M_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.OBSCOV_500M.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_obscov_500m",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 85.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_ORBIT_PNT_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.ORBIT_PNT.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_orbit_pnt",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 0.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_QC_500M_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.QC_500M.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_qc_500m",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 787410671.0,
+          "data_type": "uint32",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 1073741824.0,
+            "maximum": 2016900983.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_Q_SCAN_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.Q_SCAN.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_q_scan",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 255.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_RANGE_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.RANGE.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_range",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 65535.0,
+          "data_type": "uint16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 55737.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SENSOR_AZIMUTH_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SENSOR_AZIMUTH.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sensor_azimuth",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -32767.0,
+          "data_type": "int16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": -17660.0,
+            "maximum": 17855.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SENSOR_ZENITH_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SENSOR_ZENITH.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sensor_zenith",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -32767.0,
+          "data_type": "int16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 3.0,
+            "maximum": 6522.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SOLAR_AZIMUTH_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SOLAR_AZIMUTH.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_solar_azimuth",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -32767.0,
+          "data_type": "int16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 13324.0,
+            "maximum": 15172.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SOLAR_ZENITH_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SOLAR_ZENITH.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_solar_zenith",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -32767.0,
+          "data_type": "int16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 2856.0,
+            "maximum": 4251.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_STATE_1KM_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.STATE_1KM.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_state_1km",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 65535.0,
+          "data_type": "uint16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 40982.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SUR_REFL_B01_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SUR_REFL_B01.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b01",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 13958.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Red",
+          "common_name": "red",
+          "center_wavelength": 0.645,
+          "full_width_half_max": 50
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SUR_REFL_B02_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SUR_REFL_B02.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b02",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 11687.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Near-Infrared 1",
+          "common_name": "nir",
+          "center_wavelength": 0.859,
+          "full_width_half_max": 35
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SUR_REFL_B03_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SUR_REFL_B03.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b03",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 16000.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Blue",
+          "common_name": "blue",
+          "center_wavelength": 0.469,
+          "full_width_half_max": 20
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SUR_REFL_B04_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SUR_REFL_B04.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b04",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 13526.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Green",
+          "common_name": "green",
+          "center_wavelength": 0.555,
+          "full_width_half_max": 20
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SUR_REFL_B05_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SUR_REFL_B05.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b05",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 9974.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Near-Infrared 2",
+          "center_wavelength": 1.24,
+          "full_width_half_max": 20
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SUR_REFL_B06_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SUR_REFL_B06.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b06",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 6.0,
+            "maximum": 7682.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "SWIR 1",
+          "common_name": "swir16",
+          "center_wavelength": 1.64,
+          "full_width_half_max": 24
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MOD09GA_A2023006_h10v08_061_2023009221057_SUR_REFL_B07_tif": {
+      "href": "./MOD09GA.A2023006.h10v08.061.2023009221057.SUR_REFL_B07.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b07",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 5758.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "SWIR 2",
+          "common_name": "swir22",
+          "center_wavelength": 2.13,
+          "full_width_half_max": 50
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    }
+  },
+  "bbox": [
+    -81.1488419095665,
+    0.0,
+    -69.92175029005186,
+    10.05511074506398
+  ],
+  "stac_extensions": [
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.1/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "collection": "8d2ce872-0007-4a98-80f3-e9b2254d8005: MOD09GA"
+}

--- a/examples/items/MOD09GQ.json
+++ b/examples/items/MOD09GQ.json
@@ -1,0 +1,277 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "MOD09GQ.A2023006.h12v07.061.2023009221246",
+  "properties": {
+    "updated": "2023-01-20T03:11:33Z",
+    "created": "2023-01-20T03:11:33Z",
+    "gsd": 250,
+    "constellation": "usgs",
+    "platform": "Terra",
+    "instruments": [
+      "MODIS"
+    ],
+    "eo:cloud_cover": 0,
+    "view:off_nadir": 0,
+    "view:sun_azimuth": 0,
+    "view:sun_elevation": 0,
+    "pl:black_fill": 0,
+    "pl:data_type": "L2GL",
+    "pl:item_type": "MOD09GQ",
+    "pl:orbit_direction": "ASC",
+    "pl:pixel_resolution": 250,
+    "pl:product_generation_time": "2023-01-09T22:12:46Z",
+    "pl:product_version": "6.0.9",
+    "pl:quality_category": "standard",
+    "pl:sgrid_tile_id": "h12v07",
+    "pl:usable_data": 1,
+    "published": "2023-01-20T03:11:33Z",
+    "proj:epsg": null,
+    "datetime": "2023-01-06T11:59:59Z"
+  },
+  "geometry": {
+    "coordinates": [
+      [
+        [
+          -63.79639468961505,
+          20.10419395230241
+        ],
+        [
+          -53.16366224133632,
+          20.10419395230241
+        ],
+        [
+          -50.718026193458556,
+          10.055110745063985
+        ],
+        [
+          -60.861631432161204,
+          10.055110745063985
+        ],
+        [
+          -63.79639468961505,
+          20.10419395230241
+        ]
+      ]
+    ],
+    "type": "Polygon"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "./MOD09GQ_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./MOD09GQ_collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "MOD09GQ_A2023006_h12v07_061_2023009221246_metadata_json": {
+      "href": "./MOD09GQ.A2023006.h12v07.061.2023009221246_metadata.json",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "MOD09GQ_A2023006_h12v07_061_2023009221246_GRANULE_PNT_tif": {
+      "href": "./MOD09GQ.A2023006.h12v07.061.2023009221246.GRANULE_PNT.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_granule_pnt",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 0.0,
+          "data_type": "uint8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 1.0,
+            "maximum": 255.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GQ_A2023006_h12v07_061_2023009221246_IOBS_RES_tif": {
+      "href": "./MOD09GQ.A2023006.h12v07.061.2023009221246.IOBS_RES.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_iobs_res",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 255.0,
+          "data_type": "uint8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 6.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GQ_A2023006_h12v07_061_2023009221246_NUM_OBSERVATIONS_tif": {
+      "href": "./MOD09GQ.A2023006.h12v07.061.2023009221246.NUM_OBSERVATIONS.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_num_observations",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 1.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GQ_A2023006_h12v07_061_2023009221246_OBSCOV_tif": {
+      "href": "./MOD09GQ.A2023006.h12v07.061.2023009221246.OBSCOV.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_obscov",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 66.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GQ_A2023006_h12v07_061_2023009221246_ORBIT_PNT_tif": {
+      "href": "./MOD09GQ.A2023006.h12v07.061.2023009221246.ORBIT_PNT.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_orbit_pnt",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 0.0,
+          "data_type": "uint8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 255.0,
+            "maximum": 255.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GQ_A2023006_h12v07_061_2023009221246_QC_250M_tif": {
+      "href": "./MOD09GQ.A2023006.h12v07.061.2023009221246.QC_250M.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_qc_250m",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 2995.0,
+          "data_type": "uint16",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 4096.0,
+            "maximum": 7683.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MOD09GQ_A2023006_h12v07_061_2023009221246_SUR_REFL_B01_tif": {
+      "href": "./MOD09GQ.A2023006.h12v07.061.2023009221246.SUR_REFL_B01.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b01",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 15429.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Red",
+          "common_name": "red",
+          "center_wavelength": 0.645,
+          "full_width_half_max": 50
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MOD09GQ_A2023006_h12v07_061_2023009221246_SUR_REFL_B02_tif": {
+      "href": "./MOD09GQ.A2023006.h12v07.061.2023009221246.SUR_REFL_B02.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b02",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 14766.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Near-Infrared 1",
+          "common_name": "nir",
+          "center_wavelength": 0.859,
+          "full_width_half_max": 35
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    }
+  },
+  "bbox": [
+    -63.79639468961505,
+    10.055110745063985,
+    -50.718026193458556,
+    20.10419395230241
+  ],
+  "stac_extensions": [
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.1/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "collection": "bc2020bb-1333-4a98-9c32-02d9f2d377b3: MOD09GQ"
+}

--- a/examples/items/MOD09GQ.json
+++ b/examples/items/MOD09GQ.json
@@ -88,12 +88,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 0.0,
+          "nodata": 0,
           "data_type": "uint8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 1.0,
-            "maximum": 255.0
+            "minimum": 1,
+            "maximum": 255
           }
         }
       ],
@@ -108,12 +108,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 255.0,
+          "nodata": 255,
           "data_type": "uint8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 6.0
+            "minimum": 0,
+            "maximum": 6
           }
         }
       ],
@@ -128,12 +128,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 1.0
+            "minimum": 0,
+            "maximum": 1
           }
         }
       ],
@@ -148,12 +148,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 66.0
+            "minimum": 0,
+            "maximum": 66
           }
         }
       ],
@@ -168,12 +168,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 0.0,
+          "nodata": 0,
           "data_type": "uint8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 255.0,
-            "maximum": 255.0
+            "minimum": 255,
+            "maximum": 255
           }
         }
       ],
@@ -188,12 +188,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 2995.0,
+          "nodata": 2995,
           "data_type": "uint16",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 4096.0,
-            "maximum": 7683.0
+            "minimum": 4096,
+            "maximum": 7683
           }
         }
       ],
@@ -208,12 +208,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 15429.0
+            "minimum": -100,
+            "maximum": 15429
           }
         }
       ],
@@ -237,12 +237,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 14766.0
+            "minimum": -100,
+            "maximum": 14766
           }
         }
       ],

--- a/examples/items/MYD09GA.json
+++ b/examples/items/MYD09GA.json
@@ -88,12 +88,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 255.0,
+          "nodata": 255,
           "data_type": "uint8",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 0.0
+            "minimum": 0,
+            "maximum": 0
           }
         }
       ],
@@ -108,12 +108,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 0.0,
+          "nodata": 0,
           "data_type": "uint8",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 1.0,
-            "maximum": 255.0
+            "minimum": 1,
+            "maximum": 255
           }
         }
       ],
@@ -128,12 +128,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 255.0,
+          "nodata": 255,
           "data_type": "uint8",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 6.0
+            "minimum": 0,
+            "maximum": 6
           }
         }
       ],
@@ -148,12 +148,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 12.0
+            "minimum": 0,
+            "maximum": 12
           }
         }
       ],
@@ -168,12 +168,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 2.0
+            "minimum": 0,
+            "maximum": 2
           }
         }
       ],
@@ -188,12 +188,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 44.0
+            "minimum": 0,
+            "maximum": 44
           }
         }
       ],
@@ -208,12 +208,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 1.0
+            "minimum": 0,
+            "maximum": 1
           }
         }
       ],
@@ -228,12 +228,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 787410671.0,
+          "nodata": 787410671,
           "data_type": "uint32",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 1073741824.0,
-            "maximum": 1979712321.0
+            "minimum": 1073741824,
+            "maximum": 1979712321
           }
         }
       ],
@@ -251,8 +251,8 @@
           "data_type": "uint8",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 255.0
+            "minimum": 0,
+            "maximum": 255
           }
         }
       ],
@@ -267,12 +267,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 65535.0,
+          "nodata": 65535,
           "data_type": "uint16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 57200.0
+            "minimum": 0,
+            "maximum": 57200
           }
         }
       ],
@@ -287,12 +287,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -32767.0,
+          "nodata": -32767,
           "data_type": "int16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": -10637.0,
-            "maximum": 8681.0
+            "minimum": -10637,
+            "maximum": 8681
           }
         }
       ],
@@ -307,12 +307,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -32767.0,
+          "nodata": -32767,
           "data_type": "int16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 3235.0,
-            "maximum": 6554.0
+            "minimum": 3235,
+            "maximum": 6554
           }
         }
       ],
@@ -327,12 +327,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -32767.0,
+          "nodata": -32767,
           "data_type": "int16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": -10095.0,
-            "maximum": -6618.0
+            "minimum": -10095,
+            "maximum": -6618
           }
         }
       ],
@@ -347,12 +347,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -32767.0,
+          "nodata": -32767,
           "data_type": "int16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 1492.0,
-            "maximum": 3788.0
+            "minimum": 1492,
+            "maximum": 3788
           }
         }
       ],
@@ -367,12 +367,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 65535.0,
+          "nodata": 65535,
           "data_type": "uint16",
           "spatial_resolution": 926.6254330558331,
           "statistics": {
-            "minimum": 49.0,
-            "maximum": 40977.0
+            "minimum": 49,
+            "maximum": 40977
           }
         }
       ],
@@ -387,12 +387,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 13579.0
+            "minimum": -100,
+            "maximum": 13579
           }
         }
       ],
@@ -416,12 +416,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 8639.0
+            "minimum": -100,
+            "maximum": 8639
           }
         }
       ],
@@ -445,12 +445,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 16000.0
+            "minimum": -100,
+            "maximum": 16000
           }
         }
       ],
@@ -474,12 +474,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 13518.0
+            "minimum": -100,
+            "maximum": 13518
           }
         }
       ],
@@ -503,12 +503,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 9675.0
+            "minimum": -100,
+            "maximum": 9675
           }
         }
       ],
@@ -531,12 +531,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 5.0,
-            "maximum": 7264.0
+            "minimum": 5,
+            "maximum": 7264
           }
         }
       ],
@@ -560,12 +560,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 463.31271652791656,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 5625.0
+            "minimum": 0,
+            "maximum": 5625
           }
         }
       ],

--- a/examples/items/MYD09GA.json
+++ b/examples/items/MYD09GA.json
@@ -1,0 +1,600 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "MYD09GA.A2023009.h23v11.061.2023011074641",
+  "properties": {
+    "updated": "2023-01-13T03:42:39Z",
+    "created": "2023-01-13T03:42:39Z",
+    "gsd": 500,
+    "constellation": "usgs",
+    "platform": "Aqua",
+    "instruments": [
+      "MODIS"
+    ],
+    "eo:cloud_cover": 0,
+    "view:off_nadir": 0,
+    "view:sun_azimuth": 0,
+    "view:sun_elevation": 0,
+    "pl:black_fill": 0.07,
+    "pl:data_type": "L2GL",
+    "pl:item_type": "MYD09GA",
+    "pl:orbit_direction": "ASC",
+    "pl:pixel_resolution": 500,
+    "pl:product_generation_time": "2023-01-11T07:46:41Z",
+    "pl:product_version": "6.0.9",
+    "pl:quality_category": "standard",
+    "pl:sgrid_tile_id": "h23v11",
+    "pl:usable_data": 0.93,
+    "published": "2023-01-13T03:42:39Z",
+    "proj:epsg": null,
+    "datetime": "2023-01-09T11:59:59Z"
+  },
+  "geometry": {
+    "coordinates": [
+      [
+        [
+          53.16366224145094,
+          -20.104193952302392
+        ],
+        [
+          63.79639468972969,
+          -20.104193952302392
+        ],
+        [
+          69.24542806211541,
+          -30.141972433756095
+        ],
+        [
+          57.70452338510653,
+          -30.141972433756095
+        ],
+        [
+          53.16366224145094,
+          -20.104193952302392
+        ]
+      ]
+    ],
+    "type": "Polygon"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "./MYD09GA_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./MYD09GA_collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "MYD09GA_A2023009_h23v11_061_2023011074641_metadata_json": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641_metadata.json",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_GFLAGS_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.GFLAGS.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_gflags",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 255.0,
+          "data_type": "uint8",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 0.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_GRANULE_PNT_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.GRANULE_PNT.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_granule_pnt",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 0.0,
+          "data_type": "uint8",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 1.0,
+            "maximum": 255.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_IOBS_RES_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.IOBS_RES.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_iobs_res",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 255.0,
+          "data_type": "uint8",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 6.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_NUM_OBSERVATIONS_1KM_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.NUM_OBSERVATIONS_1KM.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_num_observations_1km",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 12.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_NUM_OBSERVATIONS_500M_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.NUM_OBSERVATIONS_500M.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_num_observations_500m",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 2.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_OBSCOV_500M_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.OBSCOV_500M.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_obscov_500m",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 44.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_ORBIT_PNT_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.ORBIT_PNT.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_orbit_pnt",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 1.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_QC_500M_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.QC_500M.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_qc_500m",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 787410671.0,
+          "data_type": "uint32",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 1073741824.0,
+            "maximum": 1979712321.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_Q_SCAN_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.Q_SCAN.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_q_scan",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "data_type": "uint8",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 255.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_RANGE_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.RANGE.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_range",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 65535.0,
+          "data_type": "uint16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 57200.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SENSOR_AZIMUTH_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SENSOR_AZIMUTH.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sensor_azimuth",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -32767.0,
+          "data_type": "int16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": -10637.0,
+            "maximum": 8681.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SENSOR_ZENITH_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SENSOR_ZENITH.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sensor_zenith",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -32767.0,
+          "data_type": "int16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 3235.0,
+            "maximum": 6554.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SOLAR_AZIMUTH_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SOLAR_AZIMUTH.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_solar_azimuth",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -32767.0,
+          "data_type": "int16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": -10095.0,
+            "maximum": -6618.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SOLAR_ZENITH_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SOLAR_ZENITH.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_solar_zenith",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -32767.0,
+          "data_type": "int16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 1492.0,
+            "maximum": 3788.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_STATE_1KM_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.STATE_1KM.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_state_1km",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 65535.0,
+          "data_type": "uint16",
+          "spatial_resolution": 926.6254330558331,
+          "statistics": {
+            "minimum": 49.0,
+            "maximum": 40977.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SUR_REFL_B01_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SUR_REFL_B01.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b01",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 13579.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Red",
+          "common_name": "red",
+          "center_wavelength": 0.645,
+          "full_width_half_max": 50
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SUR_REFL_B02_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SUR_REFL_B02.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b02",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 8639.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Near-Infrared 1",
+          "common_name": "nir",
+          "center_wavelength": 0.859,
+          "full_width_half_max": 35
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SUR_REFL_B03_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SUR_REFL_B03.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b03",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 16000.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Blue",
+          "common_name": "blue",
+          "center_wavelength": 0.469,
+          "full_width_half_max": 20
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SUR_REFL_B04_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SUR_REFL_B04.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b04",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 13518.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Green",
+          "common_name": "green",
+          "center_wavelength": 0.555,
+          "full_width_half_max": 20
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SUR_REFL_B05_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SUR_REFL_B05.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b05",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 9675.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Near-Infrared 2",
+          "center_wavelength": 1.24,
+          "full_width_half_max": 20
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SUR_REFL_B06_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SUR_REFL_B06.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b06",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 5.0,
+            "maximum": 7264.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "SWIR 1",
+          "common_name": "swir16",
+          "center_wavelength": 1.64,
+          "full_width_half_max": 24
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MYD09GA_A2023009_h23v11_061_2023011074641_SUR_REFL_B07_tif": {
+      "href": "./MYD09GA.A2023009.h23v11.061.2023011074641.SUR_REFL_B07.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b07",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 463.31271652791656,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 5625.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "SWIR 2",
+          "common_name": "swir22",
+          "center_wavelength": 2.13,
+          "full_width_half_max": 50
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    }
+  },
+  "bbox": [
+    53.16366224145094,
+    -30.141972433756095,
+    69.24542806211541,
+    -20.104193952302392
+  ],
+  "stac_extensions": [
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.1/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "collection": "45de5830-6551-4b0b-b8aa-0821374cf562: MYD09GA"
+}

--- a/examples/items/MYD09GQ.json
+++ b/examples/items/MYD09GQ.json
@@ -88,12 +88,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 0.0,
+          "nodata": 0,
           "data_type": "uint8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 1.0,
-            "maximum": 255.0
+            "minimum": 1,
+            "maximum": 255
           }
         }
       ],
@@ -108,12 +108,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 255.0,
+          "nodata": 255,
           "data_type": "uint8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 8.0
+            "minimum": 0,
+            "maximum": 8
           }
         }
       ],
@@ -128,12 +128,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 2.0
+            "minimum": 0,
+            "maximum": 2
           }
         }
       ],
@@ -148,12 +148,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -1.0,
+          "nodata": -1,
           "data_type": "int8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 56.0
+            "minimum": 0,
+            "maximum": 56
           }
         }
       ],
@@ -168,12 +168,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 0.0,
+          "nodata": 0,
           "data_type": "uint8",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 1.0,
-            "maximum": 255.0
+            "minimum": 1,
+            "maximum": 255
           }
         }
       ],
@@ -188,12 +188,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": 2995.0,
+          "nodata": 2995,
           "data_type": "uint16",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": 4096.0,
-            "maximum": 7683.0
+            "minimum": 4096,
+            "maximum": 7683
           }
         }
       ],
@@ -208,12 +208,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 13499.0
+            "minimum": -100,
+            "maximum": 13499
           }
         }
       ],
@@ -237,12 +237,12 @@
       "pl:bundle_type": "analytic_sr",
       "raster:bands": [
         {
-          "nodata": -28672.0,
+          "nodata": -28672,
           "data_type": "int16",
           "spatial_resolution": 231.65635826395828,
           "statistics": {
-            "minimum": -100.0,
-            "maximum": 8749.0
+            "minimum": -100,
+            "maximum": 8749
           }
         }
       ],

--- a/examples/items/MYD09GQ.json
+++ b/examples/items/MYD09GQ.json
@@ -1,0 +1,277 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "MYD09GQ.A2023009.h29v12.061.2023011071140",
+  "properties": {
+    "updated": "2023-01-13T03:35:26Z",
+    "created": "2023-01-13T03:35:26Z",
+    "gsd": 250,
+    "constellation": "usgs",
+    "platform": "Aqua",
+    "instruments": [
+      "MODIS"
+    ],
+    "eo:cloud_cover": 0,
+    "view:off_nadir": 0,
+    "view:sun_azimuth": 0,
+    "view:sun_elevation": 0,
+    "pl:black_fill": 0,
+    "pl:data_type": "L2GL",
+    "pl:item_type": "MYD09GQ",
+    "pl:orbit_direction": "ASC",
+    "pl:pixel_resolution": 250,
+    "pl:product_generation_time": "2023-01-11T07:11:40Z",
+    "pl:product_version": "6.0.9",
+    "pl:quality_category": "standard",
+    "pl:sgrid_tile_id": "h29v12",
+    "pl:usable_data": 1,
+    "published": "2023-01-13T03:35:26Z",
+    "proj:epsg": null,
+    "datetime": "2023-01-09T11:59:59Z"
+  },
+  "geometry": {
+    "coordinates": [
+      [
+        [
+          126.94995144715973,
+          -30.141972433756095
+        ],
+        [
+          138.4908561241686,
+          -30.141972433756095
+        ],
+        [
+          156.63388116255626,
+          -40.16456836550465
+        ],
+        [
+          143.58105773234908,
+          -40.16456836550465
+        ],
+        [
+          126.94995144715973,
+          -30.141972433756095
+        ]
+      ]
+    ],
+    "type": "Polygon"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "./MYD09GQ_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./MYD09GQ_collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "MYD09GQ_A2023009_h29v12_061_2023011071140_metadata_json": {
+      "href": "./MYD09GQ.A2023009.h29v12.061.2023011071140_metadata.json",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "MYD09GQ_A2023009_h29v12_061_2023011071140_GRANULE_PNT_tif": {
+      "href": "./MYD09GQ.A2023009.h29v12.061.2023011071140.GRANULE_PNT.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_granule_pnt",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 0.0,
+          "data_type": "uint8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 1.0,
+            "maximum": 255.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GQ_A2023009_h29v12_061_2023011071140_IOBS_RES_tif": {
+      "href": "./MYD09GQ.A2023009.h29v12.061.2023011071140.IOBS_RES.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_iobs_res",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 255.0,
+          "data_type": "uint8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 8.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GQ_A2023009_h29v12_061_2023011071140_NUM_OBSERVATIONS_tif": {
+      "href": "./MYD09GQ.A2023009.h29v12.061.2023011071140.NUM_OBSERVATIONS.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_num_observations",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 2.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GQ_A2023009_h29v12_061_2023011071140_OBSCOV_tif": {
+      "href": "./MYD09GQ.A2023009.h29v12.061.2023011071140.OBSCOV.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_obscov",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -1.0,
+          "data_type": "int8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 56.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GQ_A2023009_h29v12_061_2023011071140_ORBIT_PNT_tif": {
+      "href": "./MYD09GQ.A2023009.h29v12.061.2023011071140.ORBIT_PNT.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_orbit_pnt",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 0.0,
+          "data_type": "uint8",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 1.0,
+            "maximum": 255.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GQ_A2023009_h29v12_061_2023011071140_QC_250M_tif": {
+      "href": "./MYD09GQ.A2023009.h29v12.061.2023011071140.QC_250M.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_qc_250m",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": 2995.0,
+          "data_type": "uint16",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": 4096.0,
+            "maximum": 7683.0
+          }
+        }
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "MYD09GQ_A2023009_h29v12_061_2023011071140_SUR_REFL_B01_tif": {
+      "href": "./MYD09GQ.A2023009.h29v12.061.2023011071140.SUR_REFL_B01.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b01",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 13499.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Red",
+          "common_name": "red",
+          "center_wavelength": 0.645,
+          "full_width_half_max": 50
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    },
+    "MYD09GQ_A2023009_h29v12_061_2023011071140_SUR_REFL_B02_tif": {
+      "href": "./MYD09GQ.A2023009.h29v12.061.2023011071140.SUR_REFL_B02.tif",
+      "type": "image/tiff",
+      "pl:asset_type": "analytic_sur_refl_b02",
+      "pl:bundle_type": "analytic_sr",
+      "raster:bands": [
+        {
+          "nodata": -28672.0,
+          "data_type": "int16",
+          "spatial_resolution": 231.65635826395828,
+          "statistics": {
+            "minimum": -100.0,
+            "maximum": 8749.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Near-Infrared 1",
+          "common_name": "nir",
+          "center_wavelength": 0.859,
+          "full_width_half_max": 35
+        }
+      ],
+      "roles": [
+        "data",
+        "reflectance"
+      ]
+    }
+  },
+  "bbox": [
+    126.94995144715973,
+    -40.16456836550465,
+    156.63388116255626,
+    -30.141972433756095
+  ],
+  "stac_extensions": [
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.1/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "collection": "f113299d-7128-4c37-b7a3-c6556d8f2e5c: MYD09GQ"
+}

--- a/examples/items/Sentinel1.json
+++ b/examples/items/Sentinel1.json
@@ -12,7 +12,6 @@
       "SAR-C SAR"
     ],
     "pl:abs_orbit_number": 46686,
-    "pl:antenna_look_direction": "right",
     "pl:black_fill": 0,
     "pl:datatake_id": "366731",
     "pl:incidence_far": 46.1482,
@@ -20,14 +19,20 @@
     "pl:item_type": "Sentinel1",
     "pl:orbit_direction": "ASC",
     "pl:pixel_resolution": 10,
-    "pl:polarisation_channels": "VV,VH",
     "pl:polarisation_mode": "dual",
     "pl:quality_category": "standard",
     "pl:rel_orbit_number": 64,
-    "pl:sensor_mode": "IW",
     "pl:usable_data": 0,
     "published": "2023-01-15T08:24:34Z",
     "proj:epsg": null,
+    "sar:frequency_band": "C",
+    "sar:instrument_mode": "IW",
+    "sar:observation_direction": "right",
+    "sar:polarizations": [
+      "VV",
+      "VH"
+    ],
+    "sar:product_type": "GRD",
     "datetime": "2023-01-08T01:50:27.080000Z"
   },
   "geometry": {
@@ -188,7 +193,8 @@
   "stac_extensions": [
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sar/v1.0.0/schema.json"
   ],
   "collection": "2a42f7b8-7c70-445a-a20e-cb19628b8110: Sentinel1"
 }

--- a/examples/items/Sentinel1.json
+++ b/examples/items/Sentinel1.json
@@ -1,0 +1,194 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "S1A_IW_GRDH_1SDV_20230108T015013_20230108T015042_046686_05988B_7011",
+  "properties": {
+    "updated": "2023-01-15T08:24:34Z",
+    "created": "2023-01-15T08:24:34Z",
+    "gsd": 10,
+    "constellation": "esa",
+    "platform": "Sentinel-1-A",
+    "instruments": [
+      "SAR-C SAR"
+    ],
+    "pl:abs_orbit_number": 46686,
+    "pl:antenna_look_direction": "right",
+    "pl:black_fill": 0,
+    "pl:datatake_id": "366731",
+    "pl:incidence_far": 46.1482,
+    "pl:incidence_near": 30.7401,
+    "pl:item_type": "Sentinel1",
+    "pl:orbit_direction": "ASC",
+    "pl:pixel_resolution": 10,
+    "pl:polarisation_channels": "VV,VH",
+    "pl:polarisation_mode": "dual",
+    "pl:quality_category": "standard",
+    "pl:rel_orbit_number": 64,
+    "pl:sensor_mode": "IW",
+    "pl:usable_data": 0,
+    "published": "2023-01-15T08:24:34Z",
+    "proj:epsg": null,
+    "datetime": "2023-01-08T01:50:27.080000Z"
+  },
+  "geometry": {
+    "coordinates": [
+      [
+        [
+          [
+            -118.393974,
+            32.019535
+          ],
+          [
+            -115.714203,
+            32.427193
+          ],
+          [
+            -116.061676,
+            34.172523
+          ],
+          [
+            -118.795494,
+            33.767479
+          ],
+          [
+            -118.393974,
+            32.019535
+          ]
+        ]
+      ]
+    ],
+    "type": "MultiPolygon"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "./Sentinel1_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./Sentinel1_collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "S1A_IW_GRDH_1SDV_20230108T015013_20230108T015042_046686_05988B_7011_metadata_json": {
+      "href": "./S1A_IW_GRDH_1SDV_20230108T015013_20230108T015042_046686_05988B_7011_metadata.json",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "S1A_IW_GRDH_1SDV_20230108T015013_20230108T015042_046686_05988B_7011_ortho_analytic_vh_tif": {
+      "href": "./S1A_IW_GRDH_1SDV_20230108T015013_20230108T015042_046686_05988B_7011_ortho_analytic_vh.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "pl:asset_type": "ortho_analytic_vh",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "nodata": 0,
+          "data_type": "uint16",
+          "spatial_resolution": 10,
+          "statistics": {
+            "minimum": 2,
+            "maximum": 65535
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "VH Polarisation"
+        }
+      ],
+      "proj:epsg": 32611,
+      "proj:bbox": [
+        333720,
+        3543450,
+        620890,
+        3781690
+      ],
+      "proj:shape": [
+        23824,
+        28717
+      ],
+      "proj:transform": [
+        10,
+        0,
+        333720,
+        0,
+        -10,
+        3781690,
+        0,
+        0,
+        1
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "S1A_IW_GRDH_1SDV_20230108T015013_20230108T015042_046686_05988B_7011_ortho_analytic_vv_tif": {
+      "href": "./S1A_IW_GRDH_1SDV_20230108T015013_20230108T015042_046686_05988B_7011_ortho_analytic_vv.tif",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "pl:asset_type": "ortho_analytic_vv",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "nodata": 0,
+          "data_type": "uint16",
+          "spatial_resolution": 10,
+          "statistics": {
+            "minimum": 3350,
+            "maximum": 65535
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "VV Polarisation"
+        }
+      ],
+      "proj:epsg": 32611,
+      "proj:bbox": [
+        333720,
+        3543450,
+        620890,
+        3781690
+      ],
+      "proj:shape": [
+        23824,
+        28717
+      ],
+      "proj:transform": [
+        10,
+        0,
+        333720,
+        0,
+        -10,
+        3781690,
+        0,
+        0,
+        1
+      ],
+      "roles": [
+        "data"
+      ]
+    }
+  },
+  "bbox": [
+    -118.795494,
+    32.019535,
+    -115.714203,
+    34.172523
+  ],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "collection": "2a42f7b8-7c70-445a-a20e-cb19628b8110: Sentinel1"
+}

--- a/examples/items/Sentinel2L1C.json
+++ b/examples/items/Sentinel2L1C.json
@@ -1,0 +1,802 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "S2A_MSIL1C_20180102T222751_N0206_R072_T01LAL_20180102T233109",
+  "properties": {
+    "updated": "2019-02-22T12:06:26Z",
+    "created": "2019-02-22T12:06:26Z",
+    "gsd": 10,
+    "constellation": "esa",
+    "platform": "Sentinel-2A",
+    "instruments": [
+      "MSI"
+    ],
+    "eo:cloud_cover": 0,
+    "view:off_nadir": 7.3,
+    "view:sun_azimuth": 124.39,
+    "view:sun_elevation": 62.85,
+    "pl:abs_orbit_number": 13225,
+    "pl:black_fill": 0.89,
+    "pl:data_type": "L1C",
+    "pl:datatake_id": "GS2A_20180102T222751_013225_N02.06",
+    "pl:granule_id": "L1C_T01LAL_A013225_20180102T222753",
+    "pl:item_type": "Sentinel2L1C",
+    "pl:mgrs_grid_id": "01LAL",
+    "pl:pixel_resolution": 10,
+    "pl:product_generation_time": "2018-01-02T23:31:09Z",
+    "pl:product_id": "S2A_MSIL1C_20180102T222751_N0206_R072_T01LAL_20180102T233109",
+    "pl:quality_category": "standard",
+    "pl:rel_orbit_number": 72,
+    "pl:s2_processor_version": "02.06",
+    "pl:usable_data": 0.11,
+    "published": "2019-02-22T12:06:26Z",
+    "proj:epsg": null,
+    "datetime": "2018-01-02T22:27:53.459000Z"
+  },
+  "geometry": {
+    "coordinates": [
+      [
+        [
+          [
+            -179.63530123916556,
+            -8.368483898145028
+          ],
+          [
+            -179.69320186181105,
+            -8.352804922089712
+          ],
+          [
+            -179.69333462997616,
+            -8.353406282715763
+          ],
+          [
+            -179.92508181823732,
+            -8.294199731355903
+          ],
+          [
+            -179.92487737244602,
+            -8.293276445981428
+          ],
+          [
+            -180,
+            -8.27430580162188
+          ],
+          [
+            -180,
+            -8.1306715070165
+          ],
+          [
+            -179.6337435289789,
+            -8.133492626022388
+          ],
+          [
+            -179.63530123916556,
+            -8.368483898145028
+          ]
+        ]
+      ],
+      [
+        [
+          [
+            180,
+            -8.27430580162188
+          ],
+          [
+            179.87377848596122,
+            -8.24243120496147
+          ],
+          [
+            179.8736068712393,
+            -8.243204087664292
+          ],
+          [
+            179.6475149705035,
+            -8.188909875858313
+          ],
+          [
+            179.64777992004952,
+            -8.18772003150757
+          ],
+          [
+            179.4495813065681,
+            -8.14120909201564
+          ],
+          [
+            179.44935531778023,
+            -8.142221387068076
+          ],
+          [
+            179.3766557955715,
+            -8.125870149712362
+          ],
+          [
+            180,
+            -8.1306715070165
+          ],
+          [
+            180,
+            -8.27430580162188
+          ]
+        ]
+      ]
+    ],
+    "type": "MultiPolygon"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "./Sentinel2L1C_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./Sentinel2L1C_collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "S2A_MSIL1C_20180102T222751_N0206_R072_T01LAL_20180102T233109_metadata_json": {
+      "href": "./S2A_MSIL1C_20180102T222751_N0206_R072_T01LAL_20180102T233109_metadata.json",
+      "type": "application/json",
+      "roles": [
+        "metadata"
+      ]
+    },
+    "T01LAL_20180102T222751_B01_jp2": {
+      "href": "./T01LAL_20180102T222751_B01.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b1",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 60.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 3386.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Ultra Blue",
+          "common_name": "coastal",
+          "center_wavelength": 0.443,
+          "full_width_half_max": 0.02
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        1830,
+        1830
+      ],
+      "proj:transform": [
+        60.0,
+        0.0,
+        99960.0,
+        0.0,
+        -60.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B02_jp2": {
+      "href": "./T01LAL_20180102T222751_B02.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b2",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 10.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 3387.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Blue",
+          "common_name": "blue",
+          "center_wavelength": 0.492,
+          "full_width_half_max": 0.065
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        99960.0,
+        0.0,
+        -10.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B03_jp2": {
+      "href": "./T01LAL_20180102T222751_B03.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b3",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 10.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 3062.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Green",
+          "common_name": "green",
+          "center_wavelength": 0.559,
+          "full_width_half_max": 0.035
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        99960.0,
+        0.0,
+        -10.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B04_jp2": {
+      "href": "./T01LAL_20180102T222751_B04.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b4",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 10.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 3106.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Red",
+          "common_name": "red",
+          "center_wavelength": 0.655,
+          "full_width_half_max": 0.031
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        99960.0,
+        0.0,
+        -10.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B05_jp2": {
+      "href": "./T01LAL_20180102T222751_B05.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b5",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 20.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 2899.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Red Edge 1",
+          "common_name": "rededge",
+          "center_wavelength": 0.704,
+          "full_width_half_max": 0.015
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        99960.0,
+        0.0,
+        -20.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B06_jp2": {
+      "href": "./T01LAL_20180102T222751_B06.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b6",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 20.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 3001.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Red Edge 2",
+          "common_name": "rededge",
+          "center_wavelength": 0.74,
+          "full_width_half_max": 0.013
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        99960.0,
+        0.0,
+        -20.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B07_jp2": {
+      "href": "./T01LAL_20180102T222751_B07.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b7",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 20.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 3132.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Red Edge 3",
+          "common_name": "rededge",
+          "center_wavelength": 0.783,
+          "full_width_half_max": 0.019
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        99960.0,
+        0.0,
+        -20.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B08_jp2": {
+      "href": "./T01LAL_20180102T222751_B08.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b8",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 10.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 2908.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Near-Infrared (10m)",
+          "common_name": "nir",
+          "center_wavelength": 0.833,
+          "full_width_half_max": 0.104
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        10980,
+        10980
+      ],
+      "proj:transform": [
+        10.0,
+        0.0,
+        99960.0,
+        0.0,
+        -10.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B09_jp2": {
+      "href": "./T01LAL_20180102T222751_B09.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b9",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 60.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 647.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Near-Infrared (60m)",
+          "common_name": "nir09",
+          "center_wavelength": 0.944,
+          "full_width_half_max": 0.02
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        1830,
+        1830
+      ],
+      "proj:transform": [
+        60.0,
+        0.0,
+        99960.0,
+        0.0,
+        -60.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B10_jp2": {
+      "href": "./T01LAL_20180102T222751_B10.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b10",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 60.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 77.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Cirrus",
+          "common_name": "cirrus",
+          "center_wavelength": 1.375,
+          "full_width_half_max": 0.029
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        1830,
+        1830
+      ],
+      "proj:transform": [
+        60.0,
+        0.0,
+        99960.0,
+        0.0,
+        -60.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B11_jp2": {
+      "href": "./T01LAL_20180102T222751_B11.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b11",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 20.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 3097.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Shortwave Infrared 1",
+          "common_name": "swir16",
+          "center_wavelength": 1.61,
+          "full_width_half_max": 0.094
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        99960.0,
+        0.0,
+        -20.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B12_jp2": {
+      "href": "./T01LAL_20180102T222751_B12.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b12",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 20.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 2852.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Shortwave Infrared 2",
+          "common_name": "swir22",
+          "center_wavelength": 2.19,
+          "full_width_half_max": 0.184
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        99960.0,
+        0.0,
+        -20.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    },
+    "T01LAL_20180102T222751_B8A_jp2": {
+      "href": "./T01LAL_20180102T222751_B8A.jp2",
+      "type": "image/jp2",
+      "pl:asset_type": "analytic_b8a",
+      "pl:bundle_type": "analytic",
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 20.0,
+          "statistics": {
+            "minimum": 0.0,
+            "maximum": 3241.0
+          }
+        }
+      ],
+      "eo:bands": [
+        {
+          "name": "Near-Infrared (20m)",
+          "common_name": "nir08",
+          "center_wavelength": 0.865,
+          "full_width_half_max": 0.021
+        }
+      ],
+      "proj:epsg": 32701,
+      "proj:bbox": [
+        99960.0,
+        8990200.0,
+        209760.0,
+        9100000.0
+      ],
+      "proj:shape": [
+        5490,
+        5490
+      ],
+      "proj:transform": [
+        20.0,
+        0.0,
+        99960.0,
+        0.0,
+        -20.0,
+        9100000.0,
+        0.0,
+        0.0,
+        1.0
+      ],
+      "roles": [
+        "data"
+      ]
+    }
+  },
+  "bbox": [
+    -180.0,
+    -8.368483898145028,
+    180.0,
+    -8.125870149712362
+  ],
+  "stac_extensions": [
+    "https://planetlabs.github.io/stac-extension/v1.0.0-beta.1/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+  ],
+  "collection": "90190d3b-d9b2-4107-bb7d-3c6078bfaaf8: Sentinel2L1C"
+}

--- a/examples/items/Sentinel2L1C.json
+++ b/examples/items/Sentinel2L1C.json
@@ -155,10 +155,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 60.0,
+          "spatial_resolution": 60,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 3386.0
+            "minimum": 0,
+            "maximum": 3386
           }
         }
       ],
@@ -172,25 +172,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         1830,
         1830
       ],
       "proj:transform": [
-        60.0,
-        0.0,
-        99960.0,
-        0.0,
-        -60.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        60,
+        0,
+        99960,
+        0,
+        -60,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -204,10 +204,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 10.0,
+          "spatial_resolution": 10,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 3387.0
+            "minimum": 0,
+            "maximum": 3387
           }
         }
       ],
@@ -221,25 +221,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         10980,
         10980
       ],
       "proj:transform": [
-        10.0,
-        0.0,
-        99960.0,
-        0.0,
-        -10.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        10,
+        0,
+        99960,
+        0,
+        -10,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -253,10 +253,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 10.0,
+          "spatial_resolution": 10,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 3062.0
+            "minimum": 0,
+            "maximum": 3062
           }
         }
       ],
@@ -270,25 +270,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         10980,
         10980
       ],
       "proj:transform": [
-        10.0,
-        0.0,
-        99960.0,
-        0.0,
-        -10.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        10,
+        0,
+        99960,
+        0,
+        -10,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -302,10 +302,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 10.0,
+          "spatial_resolution": 10,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 3106.0
+            "minimum": 0,
+            "maximum": 3106
           }
         }
       ],
@@ -319,25 +319,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         10980,
         10980
       ],
       "proj:transform": [
-        10.0,
-        0.0,
-        99960.0,
-        0.0,
-        -10.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        10,
+        0,
+        99960,
+        0,
+        -10,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -351,10 +351,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 20.0,
+          "spatial_resolution": 20,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 2899.0
+            "minimum": 0,
+            "maximum": 2899
           }
         }
       ],
@@ -368,25 +368,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         5490,
         5490
       ],
       "proj:transform": [
-        20.0,
-        0.0,
-        99960.0,
-        0.0,
-        -20.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        20,
+        0,
+        99960,
+        0,
+        -20,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -400,10 +400,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 20.0,
+          "spatial_resolution": 20,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 3001.0
+            "minimum": 0,
+            "maximum": 3001
           }
         }
       ],
@@ -417,25 +417,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         5490,
         5490
       ],
       "proj:transform": [
-        20.0,
-        0.0,
-        99960.0,
-        0.0,
-        -20.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        20,
+        0,
+        99960,
+        0,
+        -20,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -449,10 +449,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 20.0,
+          "spatial_resolution": 20,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 3132.0
+            "minimum": 0,
+            "maximum": 3132
           }
         }
       ],
@@ -466,25 +466,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         5490,
         5490
       ],
       "proj:transform": [
-        20.0,
-        0.0,
-        99960.0,
-        0.0,
-        -20.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        20,
+        0,
+        99960,
+        0,
+        -20,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -498,10 +498,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 10.0,
+          "spatial_resolution": 10,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 2908.0
+            "minimum": 0,
+            "maximum": 2908
           }
         }
       ],
@@ -515,25 +515,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         10980,
         10980
       ],
       "proj:transform": [
-        10.0,
-        0.0,
-        99960.0,
-        0.0,
-        -10.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        10,
+        0,
+        99960,
+        0,
+        -10,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -547,10 +547,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 60.0,
+          "spatial_resolution": 60,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 647.0
+            "minimum": 0,
+            "maximum": 647
           }
         }
       ],
@@ -564,25 +564,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         1830,
         1830
       ],
       "proj:transform": [
-        60.0,
-        0.0,
-        99960.0,
-        0.0,
-        -60.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        60,
+        0,
+        99960,
+        0,
+        -60,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -596,10 +596,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 60.0,
+          "spatial_resolution": 60,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 77.0
+            "minimum": 0,
+            "maximum": 77
           }
         }
       ],
@@ -613,25 +613,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         1830,
         1830
       ],
       "proj:transform": [
-        60.0,
-        0.0,
-        99960.0,
-        0.0,
-        -60.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        60,
+        0,
+        99960,
+        0,
+        -60,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -645,10 +645,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 20.0,
+          "spatial_resolution": 20,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 3097.0
+            "minimum": 0,
+            "maximum": 3097
           }
         }
       ],
@@ -662,25 +662,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         5490,
         5490
       ],
       "proj:transform": [
-        20.0,
-        0.0,
-        99960.0,
-        0.0,
-        -20.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        20,
+        0,
+        99960,
+        0,
+        -20,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -694,10 +694,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 20.0,
+          "spatial_resolution": 20,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 2852.0
+            "minimum": 0,
+            "maximum": 2852
           }
         }
       ],
@@ -711,25 +711,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         5490,
         5490
       ],
       "proj:transform": [
-        20.0,
-        0.0,
-        99960.0,
-        0.0,
-        -20.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        20,
+        0,
+        99960,
+        0,
+        -20,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -743,10 +743,10 @@
       "raster:bands": [
         {
           "data_type": "uint16",
-          "spatial_resolution": 20.0,
+          "spatial_resolution": 20,
           "statistics": {
-            "minimum": 0.0,
-            "maximum": 3241.0
+            "minimum": 0,
+            "maximum": 3241
           }
         }
       ],
@@ -760,25 +760,25 @@
       ],
       "proj:epsg": 32701,
       "proj:bbox": [
-        99960.0,
-        8990200.0,
-        209760.0,
-        9100000.0
+        99960,
+        8990200,
+        209760,
+        9100000
       ],
       "proj:shape": [
         5490,
         5490
       ],
       "proj:transform": [
-        20.0,
-        0.0,
-        99960.0,
-        0.0,
-        -20.0,
-        9100000.0,
-        0.0,
-        0.0,
-        1.0
+        20,
+        0,
+        99960,
+        0,
+        -20,
+        9100000,
+        0,
+        0,
+        1
       ],
       "roles": [
         "data"
@@ -786,9 +786,9 @@
     }
   },
   "bbox": [
-    -180.0,
+    -180,
     -8.368483898145028,
-    180.0,
+    180,
     -8.125870149712362
   ],
   "stac_extensions": [

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1029,7 +1029,7 @@
               "const": "usgs"
             },
             "platform": {
-              "pattern": "Landsat8"
+              "const": "Landsat8"
             }
           }
         },
@@ -1039,7 +1039,7 @@
               "const": "usgs"
             },
             "platform": {
-              "pattern": "Terra"
+              "pattern": "Terra|Aqua"
             }
           }
         },
@@ -1079,7 +1079,7 @@
               "const": "esa"
             },
             "platform": {
-              "pattern": "SSC\\d+"
+              "pattern": "Sentinel\\S+"
             }
           }
         },
@@ -1089,7 +1089,7 @@
               "const": "skysat"
             },
             "platform": {
-              "pattern": "Sentinel\\S+"
+              "pattern": "SSC\\d+"
             }
           }
         }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -437,7 +437,11 @@
                     "pl:black_fill",
                     "pl:pixel_resolution",
                     "pl:quality_category",
-                    "eo:cloud_cover",
+                    "sar:frequency_band",
+                    "sar:instrument_mode",
+                    "sar:observation_direction",
+                    "sar:polarizations",
+                    "sar:product_type",
                     "gsd"
                   ],
                   "properties": {

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -32,7 +32,6 @@
             "type": "object",
             "required": [
               "pl:item_type",
-              "pl:strip_id",
               "constellation",
               "platform",
               "datetime",
@@ -41,6 +40,196 @@
               "view:sun_elevation"
             ],
             "allOf": [
+              {
+                "title": "Landsat8L1G",
+                "if": {
+                  "$ref": "#/definitions/types/Landsat8L1G"
+                },
+                "then": {
+                  "required": [
+                    "pl:pixel_resolution",
+                    "pl:quality_category",
+                    "gsd"
+                  ],
+                  "properties": {
+                    "pl:item_type": {
+                      "$ref": "#/definitions/fields/pl:item_type"
+                    },
+                    "pl:quality_category": {
+                      "$ref": "#/definitions/fields/pl:quality_category"
+                    },
+                    "pl:pixel_resolution": {
+                      "$ref": "#/definitions/fields/pl:pixel_resolution"
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/properties/common_metadata/landsat"
+                    }
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "$ref": "#/definitions/types/Landsat8L1G"
+                  }
+                }
+              },
+              {
+                "title": "MOD09GA",
+                "if": {
+                  "$ref": "#/definitions/types/MOD09GA"
+                },
+                "then": {
+                  "required": [
+                    "pl:black_fill",
+                    "pl:pixel_resolution",
+                    "pl:quality_category",
+                    "eo:cloud_cover",
+                    "gsd"
+                  ],
+                  "properties": {
+                    "pl:item_type": {
+                      "$ref": "#/definitions/fields/pl:item_type"
+                    },
+                    "pl:black_fill": {
+                      "$ref": "#/definitions/fields/pl:black_fill"
+                    },
+                    "pl:quality_category": {
+                      "$ref": "#/definitions/fields/pl:quality_category"
+                    },
+                    "pl:pixel_resolution": {
+                      "$ref": "#/definitions/fields/pl:pixel_resolution"
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/properties/common_metadata/modis"
+                    }
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "$ref": "#/definitions/types/MOD09GA"
+                  }
+                }
+              },
+              {
+                "title": "MOD09GQ",
+                "if": {
+                  "$ref": "#/definitions/types/MOD09GQ"
+                },
+                "then": {
+                  "required": [
+                    "pl:black_fill",
+                    "pl:pixel_resolution",
+                    "pl:quality_category",
+                    "eo:cloud_cover",
+                    "gsd"
+                  ],
+                  "properties": {
+                    "pl:item_type": {
+                      "$ref": "#/definitions/fields/pl:item_type"
+                    },
+                    "pl:black_fill": {
+                      "$ref": "#/definitions/fields/pl:black_fill"
+                    },
+                    "pl:quality_category": {
+                      "$ref": "#/definitions/fields/pl:quality_category"
+                    },
+                    "pl:pixel_resolution": {
+                      "$ref": "#/definitions/fields/pl:pixel_resolution"
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/properties/common_metadata/modis"
+                    }
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "$ref": "#/definitions/types/MOD09GQ"
+                  }
+                }
+              },
+              {
+                "title": "MYD09GA",
+                "if": {
+                  "$ref": "#/definitions/types/MYD09GA"
+                },
+                "then": {
+                  "required": [
+                    "pl:black_fill",
+                    "pl:pixel_resolution",
+                    "pl:quality_category",
+                    "eo:cloud_cover",
+                    "gsd"
+                  ],
+                  "properties": {
+                    "pl:item_type": {
+                      "$ref": "#/definitions/fields/pl:item_type"
+                    },
+                    "pl:black_fill": {
+                      "$ref": "#/definitions/fields/pl:black_fill"
+                    },
+                    "pl:quality_category": {
+                      "$ref": "#/definitions/fields/pl:quality_category"
+                    },
+                    "pl:pixel_resolution": {
+                      "$ref": "#/definitions/fields/pl:pixel_resolution"
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/properties/common_metadata/modis"
+                    }
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "$ref": "#/definitions/types/MYD09GA"
+                  }
+                }
+              },
+              {
+                "title": "MYD09GQ",
+                "if": {
+                  "$ref": "#/definitions/types/MYD09GQ"
+                },
+                "then": {
+                  "required": [
+                    "pl:black_fill",
+                    "pl:pixel_resolution",
+                    "pl:quality_category",
+                    "eo:cloud_cover",
+                    "gsd"
+                  ],
+                  "properties": {
+                    "pl:item_type": {
+                      "$ref": "#/definitions/fields/pl:item_type"
+                    },
+                    "pl:black_fill": {
+                      "$ref": "#/definitions/fields/pl:black_fill"
+                    },
+                    "pl:quality_category": {
+                      "$ref": "#/definitions/fields/pl:quality_category"
+                    },
+                    "pl:pixel_resolution": {
+                      "$ref": "#/definitions/fields/pl:pixel_resolution"
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/properties/common_metadata/modis"
+                    }
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "$ref": "#/definitions/types/MYD09GQ"
+                  }
+                }
+              },
               {
                 "title": "PSOrthoTile",
                 "if": {
@@ -55,6 +244,7 @@
                     "pl:pixel_resolution",
                     "pl:publishing_stage",
                     "pl:quality_category",
+                    "pl:strip_id",
                     "instruments",
                     "gsd",
                     "eo:cloud_cover",
@@ -113,6 +303,7 @@
                     "pl:pixel_resolution",
                     "pl:publishing_stage",
                     "pl:quality_category",
+                    "pl:strip_id",
                     "instruments",
                     "gsd",
                     "eo:cloud_cover",
@@ -165,6 +356,7 @@
                     "pl:grid_cell",
                     "pl:ground_control",
                     "pl:pixel_resolution",
+                    "pl:strip_id",
                     "gsd",
                     "eo:cloud_cover"
                   ],
@@ -208,6 +400,7 @@
                 "then": {
                   "required": [
                     "pl:black_fill",
+                    "pl:strip_id",
                     "gsd",
                     "eo:cloud_cover"
                   ],
@@ -235,6 +428,84 @@
                 }
               },
               {
+                "title": "Sentinel1",
+                "if": {
+                  "$ref": "#/definitions/types/Sentinel1"
+                },
+                "then": {
+                  "required": [
+                    "pl:black_fill",
+                    "pl:pixel_resolution",
+                    "pl:quality_category",
+                    "eo:cloud_cover",
+                    "gsd"
+                  ],
+                  "properties": {
+                    "pl:item_type": {
+                      "$ref": "#/definitions/fields/pl:item_type"
+                    },
+                    "pl:black_fill": {
+                      "$ref": "#/definitions/fields/pl:black_fill"
+                    },
+                    "pl:quality_category": {
+                      "$ref": "#/definitions/fields/pl:quality_category"
+                    },
+                    "pl:pixel_resolution": {
+                      "$ref": "#/definitions/fields/pl:pixel_resolution"
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/properties/common_metadata/sentinel"
+                    }
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "$ref": "#/definitions/types/Sentinel1"
+                  }
+                }
+              },
+              {
+                "title": "Sentinel2L1C",
+                "if": {
+                  "$ref": "#/definitions/types/Sentinel2L1C"
+                },
+                "then": {
+                  "required": [
+                    "pl:black_fill",
+                    "pl:pixel_resolution",
+                    "pl:quality_category",
+                    "eo:cloud_cover",
+                    "gsd"
+                  ],
+                  "properties": {
+                    "pl:item_type": {
+                      "$ref": "#/definitions/fields/pl:item_type"
+                    },
+                    "pl:black_fill": {
+                      "$ref": "#/definitions/fields/pl:black_fill"
+                    },
+                    "pl:quality_category": {
+                      "$ref": "#/definitions/fields/pl:quality_category"
+                    },
+                    "pl:pixel_resolution": {
+                      "$ref": "#/definitions/fields/pl:pixel_resolution"
+                    }
+                  },
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/properties/common_metadata/sentinel"
+                    }
+                  ]
+                },
+                "else": {
+                  "not": {
+                    "$ref": "#/definitions/types/Sentinel2L1C"
+                  }
+                }
+              },
+              {
                 "title": "SkySatCollect",
                 "if": {
                   "$ref": "#/definitions/types/SkySatCollect"
@@ -246,6 +517,7 @@
                     "pl:pixel_resolution",
                     "pl:publishing_stage",
                     "pl:quality_category",
+                    "pl:strip_id",
                     "gsd",
                     "eo:cloud_cover",
                     "eo:snow_cover",
@@ -298,6 +570,7 @@
                     "pl:pixel_resolution",
                     "pl:publishing_stage",
                     "pl:quality_category",
+                    "pl:strip_id",
                     "gsd",
                     "eo:cloud_cover",
                     "eo:snow_cover",
@@ -347,6 +620,7 @@
                   "required": [
                     "pl:publishing_stage",
                     "pl:quality_category",
+                    "pl:strip_id",
                     "view:azimuth"
                   ],
                   "properties": {
@@ -515,13 +789,56 @@
               "analytic",
               "analytic_5b",
               "analytic_5b_xml",
+              "analytic_8b",
+              "analytic_8b_sr",
+              "analytic_8b_xml",
+              "analytic_b1",
+              "analytic_b10",
+              "analytic_b11",
+              "analytic_b12",
+              "analytic_b2",
+              "analytic_b3",
+              "analytic_b4",
+              "analytic_b5",
+              "analytic_b6",
+              "analytic_b7",
+              "analytic_b8",
+              "analytic_b8a",
+              "analytic_b9",
+              "analytic_bqa",
               "analytic_dn",
               "analytic_dn_xml",
+              "analytic_gflags",
+              "analytic_granule_pnt",
+              "analytic_iobs_res",
+              "analytic_ms",
+              "analytic_num_observations",
+              "analytic_num_observations_1km",
+              "analytic_num_observations_500m",
+              "analytic_obscov",
+              "analytic_obscov_500m",
+              "analytic_orbit_pnt",
+              "analytic_q_scan",
+              "analytic_qc_250m",
+              "analytic_qc_500m",
+              "analytic_range",
+              "analytic_sensor_azimuth",
+              "analytic_sensor_zenith",
+              "analytic_solar_azimuth",
+              "analytic_solar_zenith",
               "analytic_sr",
+              "analytic_state_1km",
+              "analytic_sur_refl_b01",
+              "analytic_sur_refl_b02",
+              "analytic_sur_refl_b03",
+              "analytic_sur_refl_b04",
+              "analytic_sur_refl_b05",
+              "analytic_sur_refl_b06",
+              "analytic_sur_refl_b07",
               "analytic_xml",
               "basic_analytic",
-              "basic_analytic_4b",
               "basic_analytic_4b_rpc",
+              "basic_analytic_4b",
               "basic_analytic_4b_xml",
               "basic_analytic_8b",
               "basic_analytic_8b_xml",
@@ -536,8 +853,14 @@
               "basic_analytic_b5",
               "basic_analytic_b5_nitf",
               "basic_analytic_dn",
+              "basic_analytic_dn_nitf",
               "basic_analytic_dn_rpc",
+              "basic_analytic_dn_rpc_nitf",
+              "basic_analytic_dn_xml",
+              "basic_analytic_dn_xml_nitf",
+              "basic_analytic_nitf",
               "basic_analytic_rpc",
+              "basic_analytic_rpc_nitf",
               "basic_analytic_sci",
               "basic_analytic_udm",
               "basic_analytic_udm2",
@@ -554,6 +877,8 @@
               "basic_udm",
               "basic_udm2",
               "browse",
+              "metadata_aux",
+              "metadata_txt",
               "ortho_analytic",
               "ortho_analytic_3b",
               "ortho_analytic_3b_xml",
@@ -564,9 +889,13 @@
               "ortho_analytic_8b_sr",
               "ortho_analytic_8b_xml",
               "ortho_analytic_dn",
+              "ortho_analytic_hh",
+              "ortho_analytic_hv",
               "ortho_analytic_sr",
               "ortho_analytic_udm",
               "ortho_analytic_udm2",
+              "ortho_analytic_vh",
+              "ortho_analytic_vv",
               "ortho_panchromatic",
               "ortho_panchromatic_dn",
               "ortho_panchromatic_udm",
@@ -593,6 +922,41 @@
       }
     },
     "types": {
+      "Landsat8L1G": {
+        "properties": {
+          "pl:item_type": {
+            "const": "Landsat8L1G"
+          }
+        }
+      },
+      "MOD09GA": {
+        "properties": {
+          "pl:item_type": {
+            "const": "MOD09GA"
+          }
+        }
+      },
+      "MOD09GQ": {
+        "properties": {
+          "pl:item_type": {
+            "const": "MOD09GQ"
+          }
+        }
+      },
+      "MYD09GA": {
+        "properties": {
+          "pl:item_type": {
+            "const": "MYD09GA"
+          }
+        }
+      },
+      "MYD09GQ": {
+        "properties": {
+          "pl:item_type": {
+            "const": "MYD09GQ"
+          }
+        }
+      },
       "PSOrthoTile": {
         "properties": {
           "pl:item_type": {
@@ -621,6 +985,20 @@
           }
         }
       },
+      "Sentinel1": {
+        "properties": {
+          "pl:item_type": {
+            "const": "Sentinel1"
+          }
+        }
+      },
+      "Sentinel2L1C": {
+        "properties": {
+          "pl:item_type": {
+            "const": "Sentinel2L1C"
+          }
+        }
+      },
       "SkySatCollect": {
         "properties": {
           "pl:item_type": {
@@ -645,6 +1023,26 @@
     },
     "properties": {
       "common_metadata": {
+        "landsat": {
+          "properties": {
+            "constellation": {
+              "const": "usgs"
+            },
+            "platform": {
+              "pattern": "Landsat8"
+            }
+          }
+        },
+        "modis": {
+          "properties": {
+            "constellation": {
+              "const": "usgs"
+            },
+            "platform": {
+              "pattern": "Terra"
+            }
+          }
+        },
         "ps": {
           "properties": {
             "constellation": {
@@ -675,13 +1073,23 @@
             }
           }
         },
+        "sentinel": {
+          "properties": {
+            "constellation": {
+              "const": "esa"
+            },
+            "platform": {
+              "pattern": "SSC\\d+"
+            }
+          }
+        },
         "ss": {
           "properties": {
             "constellation": {
               "const": "skysat"
             },
             "platform": {
-              "pattern": "SSC\\d+"
+              "pattern": "Sentinel\\S+"
             }
           }
         }
@@ -712,12 +1120,19 @@
       "pl:item_type": {
         "type": "string",
         "enum": [
+          "Landsat8L1G",
           "PSOrthoTile",
           "PSScene",
           "PSScene3Band",
           "PSScene4Band",
+          "MOD09GA",
+          "MOD09GQ",
+          "MYD09GA",
+          "MYD09GQ",
           "REOrthoTile",
           "REScene",
+          "Sentinel1",
+          "Sentinel2L1C",
           "SkySatCollect",
           "SkySatScene",
           "SkySatVideo"

--- a/mapping.md
+++ b/mapping.md
@@ -44,6 +44,6 @@ STAC Item properties (if not stated otherwise) and lists for which `pl:item_type
 | view:sun_elevation                      | **sun_elevation**          | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | updated (assets)                        | **updated**                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | -                                       | usable_data                | ✓ |   | ✓ | ✓ |   |   |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| view:off_nadir (absolute value)         | **view_angle**             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| view:off_nadir (absolute value)         | **view_angle**             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
 | -                                       | visible_confidence_percent | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | -                                       | visible_percent            | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |

--- a/mapping.md
+++ b/mapping.md
@@ -3,47 +3,47 @@
 The following table maps the Planet Item Properties as defined for their individual products to the
 STAC Item properties (if not stated otherwise) and lists for which `pl:item_type` they apply:
 
-| STAC | Planet | PSOrthoThile | PSScene | REOrthoTile | REScene | SkySatCollect | SkySatScene | SkySatVideo |
-| ---- | ------ | ------------ | ------- | ----------- | ------- | ------------- | ----------- | ----------- |
-| assets (top-level, different structure) | **_permissions**           | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| geometry (top-level)                    | **geometry**               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| id (top-level)                          | **id**                     | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| datetime                                | **acquired**               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| -                                       | anomalous_pixels           | ✓ | ✓ | ✓ | ✓ |   |   |   |
-| *pl:black_fill*                         | black_fill                 | ✓ |   | ✓ | ✓ |   |   |   |
-| -                                       | camera_id                  |   |   |   |   |   | ✓ | ✓ |
-| collection (top-level)                  | catalog_id                 |   |   | ✓ | ✓ |   |   |   |
-| -                                       | clear_confidence_percent   | ✓ | ✓ |   |   | ✓ | ✓ |   |
-| *pl:clear_percent*                      | clear_percent              | ✓ | ✓ |   |   | ✓ | ✓ |   |
-| eo:cloud_cover                          | **cloud_cover**            | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| -                                       | cloud_percent              | ✓ | ✓ |   |   | ✓ | ✓ |   |
-| proj.shape\[1] (assets)                 | columns                    | ✓ |   | ✓ | ✓ |   |   |   |
-| proj:epsg (assets)                      | epsg_code                  | ✓ |   | ✓ |   |   |   |   |
-| *pl:grid_cell*                          | grid_cell                  | ✓ |   | ✓ |   |   |   |   |
-| *pl:ground_control*                     | ground_control             | ✓ | ✓ | ✓ |   |   | ✓ |   |
-| *pl:ground_control_ratio*               | ground_control_ratio       |   |   |   |   | ✓ |   |   |
-| gsd                                     | **gsd**                    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-| -                                       | heavy_haze_percent         | ✓ | ✓ |   |   | ✓ | ✓ |   |
-| instruments\[0]                         | instrument                 | ✓ | ✓ |   |   |   |   |   |
-| *pl:item_type*                          | **item_type**              | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| -                                       | light_haze_percent         | ✓ | ✓ |   |   | ✓ | ✓ |   |
-| -                                       | origin_x                   | ✓ |   | ✓ |   |   |   |   |
-| -                                       | origin_y                   | ✓ |   | ✓ |   |   |   |   |
-| pl:pixel_resolution (spatial_resolution) | pixel_resolution          | ✓ | ✓ | ✓ |   | ✓ | ✓ |   |
-| constellation                           | **provider**               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| published (assets)                      | **published**              | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| *pl:publishing_stage*                   | publishing_stage           | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |
-| *pl:quality_category*                   | quality_category           | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |
-| proj.shape\[0] (assets)                 | rows                       | ✓ | ✓ | ✓ | ✓ |   |   |   |
-| view:azimuth                            | satellite_azimuth          | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |
-| platform                                | **satellite_id**           | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| -                                       | shadow_percent             |   | ✓ |   |   | ✓ | ✓ |   |
-| eo:snow_cover                           | snow_ice_percent           |   | ✓ |   |   | ✓ | ✓ |   |
-| *pl:strip_id*                           | **strip_id**               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| view:sun_azimuth                        | **sun_azimuth**            | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| view:sun_elevation                      | **sun_elevation**          | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| updated (assets)                        | **updated**                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| -                                       | usable_data                | ✓ |   | ✓ | ✓ |   |   |   |
-| view:off_nadir (absolute value)         | **view_angle**             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| -                                       | visible_confidence_percent | ✓ | ✓ |   |   | ✓ | ✓ |   |
-| -                                       | visible_percent            | ✓ | ✓ |   |   | ✓ | ✓ |   |
+| STAC | Planet | PSOrthoThile | PSScene | REOrthoTile | REScene | SkySatCollect | SkySatScene | SkySatVideo | Landsat8L1G | MOD09GA | MOD09GQ | MYD09GA | MYD09GQ | Sentinel1 | Sentinel2L1C |
+| ---- | ------ | ------------ | ------- | ----------- | ------- | ------------- | ----------- | ----------- | ----------- | ------- | ------- | ------- | ------- | --------- | ------------ |
+| assets (top-level, different structure) | **_permissions**           | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| geometry (top-level)                    | **geometry**               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| id (top-level)                          | **id**                     | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| datetime                                | **acquired**               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| -                                       | anomalous_pixels           | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ |
+| *pl:black_fill*                         | black_fill                 | ✓ |   | ✓ | ✓ |   |   |   |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| -                                       | camera_id                  |   |   |   |   |   | ✓ | ✓ |   |   |   |   |   |   |   |
+| collection (top-level)                  | catalog_id                 |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |   |
+| -                                       | clear_confidence_percent   | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   | 
+| *pl:clear_percent*                      | clear_percent              | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
+| eo:cloud_cover                          | cloud_cover                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| -                                       | cloud_percent              | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
+| proj.shape\[1] (assets)                 | columns                    | ✓ |   | ✓ | ✓ |   |   |   | ✓ |   |   |   |   | ✓ | ✓ |
+| proj:epsg (assets)                      | epsg_code                  | ✓ |   | ✓ |   |   |   |   | ✓ |   |   |   |   | ✓ | ✓ |
+| *pl:grid_cell*                          | grid_cell                  | ✓ |   | ✓ |   |   |   |   |   |   |   |   |   |   |   |
+| *pl:ground_control*                     | ground_control             | ✓ | ✓ | ✓ |   |   | ✓ |   |   |   |   |   |   |   |   | 
+| *pl:ground_control_ratio*               | ground_control_ratio       |   |   |   |   | ✓ |   |   |   |   |   |   |   |   |   |
+| gsd                                     | **gsd**                    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   
+| -                                       | heavy_haze_percent         | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
+| instruments\[0]                         | instrument                 | ✓ | ✓ |   |   |   |   |   | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
+| *pl:item_type*                          | **item_type**              | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| -                                       | light_haze_percent         | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
+| -                                       | origin_x                   | ✓ |   | ✓ |   |   |   |   | ✓ |   |   |   |   |   | ✓ |
+| -                                       | origin_y                   | ✓ |   | ✓ |   |   |   |   | ✓ |   |   |   |   |   | ✓ |
+| pl:pixel_resolution (spatial_resolution) | pixel_resolution          | ✓ | ✓ | ✓ |   | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
+| constellation                           | **provider**               | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| published (assets)                      | **published**              | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| *pl:publishing_stage*                   | publishing_stage           | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |
+| *pl:quality_category*                   | quality_category           | ✓ | ✓ |   |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| proj.shape\[0] (assets)                 | rows                       | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓ |   |   |   |   | ✓ | ✓ |
+| view:azimuth                            | satellite_azimuth          | ✓ | ✓ |   |   | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |
+| platform                                | **satellite_id**           | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| -                                       | shadow_percent             |   | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
+| eo:snow_cover                           | snow_ice_percent           |   | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
+| *pl:strip_id*                           | strip_id                   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   
+| view:sun_azimuth                        | **sun_azimuth**            | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| view:sun_elevation                      | **sun_elevation**          | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| updated (assets)                        | **updated**                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| -                                       | usable_data                | ✓ |   | ✓ | ✓ |   |   |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| view:off_nadir (absolute value)         | **view_angle**             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   
+| -                                       | visible_confidence_percent | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
+| -                                       | visible_percent            | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |

--- a/mapping.md
+++ b/mapping.md
@@ -13,16 +13,16 @@ STAC Item properties (if not stated otherwise) and lists for which `pl:item_type
 | *pl:black_fill*                         | black_fill                 | ✓ |   | ✓ | ✓ |   |   |   |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | -                                       | camera_id                  |   |   |   |   |   | ✓ | ✓ |   |   |   |   |   |   |   |
 | collection (top-level)                  | catalog_id                 |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |   |
-| -                                       | clear_confidence_percent   | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   | 
+| -                                       | clear_confidence_percent   | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | *pl:clear_percent*                      | clear_percent              | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | eo:cloud_cover                          | cloud_cover                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | -                                       | cloud_percent              | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | proj.shape\[1] (assets)                 | columns                    | ✓ |   | ✓ | ✓ |   |   |   | ✓ |   |   |   |   | ✓ | ✓ |
 | proj:epsg (assets)                      | epsg_code                  | ✓ |   | ✓ |   |   |   |   | ✓ |   |   |   |   | ✓ | ✓ |
 | *pl:grid_cell*                          | grid_cell                  | ✓ |   | ✓ |   |   |   |   |   |   |   |   |   |   |   |
-| *pl:ground_control*                     | ground_control             | ✓ | ✓ | ✓ |   |   | ✓ |   |   |   |   |   |   |   |   | 
+| *pl:ground_control*                     | ground_control             | ✓ | ✓ | ✓ |   |   | ✓ |   |   |   |   |   |   |   |   |
 | *pl:ground_control_ratio*               | ground_control_ratio       |   |   |   |   | ✓ |   |   |   |   |   |   |   |   |   |
-| gsd                                     | **gsd**                    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   
+| gsd                                     | **gsd**                    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |  
 | -                                       | heavy_haze_percent         | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | instruments\[0]                         | instrument                 | ✓ | ✓ |   |   |   |   |   | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
 | *pl:item_type*                          | **item_type**              | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
@@ -39,11 +39,11 @@ STAC Item properties (if not stated otherwise) and lists for which `pl:item_type
 | platform                                | **satellite_id**           | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | -                                       | shadow_percent             |   | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | eo:snow_cover                           | snow_ice_percent           |   | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
-| *pl:strip_id*                           | strip_id                   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |   
+| *pl:strip_id*                           | strip_id                   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   |   |
 | view:sun_azimuth                        | **sun_azimuth**            | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | view:sun_elevation                      | **sun_elevation**          | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | updated (assets)                        | **updated**                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | -                                       | usable_data                | ✓ |   | ✓ | ✓ |   |   |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| view:off_nadir (absolute value)         | **view_angle**             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   
+| view:off_nadir (absolute value)         | **view_angle**             | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | -                                       | visible_confidence_percent | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | -                                       | visible_percent            | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |

--- a/mapping.md
+++ b/mapping.md
@@ -15,7 +15,7 @@ STAC Item properties (if not stated otherwise) and lists for which `pl:item_type
 | collection (top-level)                  | catalog_id                 |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |   |   |
 | -                                       | clear_confidence_percent   | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | *pl:clear_percent*                      | clear_percent              | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
-| eo:cloud_cover                          | cloud_cover                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| eo:cloud_cover                          | cloud_cover                | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
 | -                                       | cloud_percent              | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | proj.shape\[1] (assets)                 | columns                    | ✓ |   | ✓ | ✓ |   |   |   | ✓ |   |   |   |   | ✓ | ✓ |
 | proj:epsg (assets)                      | epsg_code                  | ✓ |   | ✓ |   |   |   |   | ✓ |   |   |   |   | ✓ | ✓ |

--- a/mapping.md
+++ b/mapping.md
@@ -22,7 +22,7 @@ STAC Item properties (if not stated otherwise) and lists for which `pl:item_type
 | *pl:grid_cell*                          | grid_cell                  | ✓ |   | ✓ |   |   |   |   |   |   |   |   |   |   |   |
 | *pl:ground_control*                     | ground_control             | ✓ | ✓ | ✓ |   |   | ✓ |   |   |   |   |   |   |   |   |
 | *pl:ground_control_ratio*               | ground_control_ratio       |   |   |   |   | ✓ |   |   |   |   |   |   |   |   |   |
-| gsd                                     | **gsd**                    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |  
+| gsd                                     | **gsd**                    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | -                                       | heavy_haze_percent         | ✓ | ✓ |   |   | ✓ | ✓ |   |   |   |   |   |   |   |   |
 | instruments\[0]                         | instrument                 | ✓ | ✓ |   |   |   |   |   | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ |
 | *pl:item_type*                          | **item_type**              | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |


### PR DESCRIPTION
Some Planet APIs (including orders) support data that doesn't come from Planet constellations. These are some changes to accommodate the item types `Landsat8L1G`, `MOD09GA`, `MOD09GQ`, `MYD09GA`, `MYD09GQ`, `Sentinel1`,`Sentinel2L1C`.  

One consequence of this is that `pl:strip_id` can no longer be required across all item types.