### PR TITLE
Make other examples valid and link to them #11, #15

### DIFF
--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -49,6 +49,41 @@
       "href": "./items/skysatscene.json",
       "rel": "item",
       "type": "application/geo+json"
+    },
+    {
+      "href": "./items/Landsat8L1G.json",
+      "rel": "item",
+      "type": "application/geo+json"
+    },
+    {
+      "href": "./items/MOD09GA.json",
+      "rel": "item",
+      "type": "application/geo+json"
+    },
+    {
+      "href": "./items/MOD09GQ.json",
+      "rel": "item",
+      "type": "application/geo+json"
+    },
+    {
+      "href": "./items/MYD09GA.json",
+      "rel": "item",
+      "type": "application/geo+json"
+    },
+    {
+      "href": "./items/MYD09GQ.json",
+      "rel": "item",
+      "type": "application/geo+json"
+    },
+    {
+      "href": "./items/Sentinel1.json",
+      "rel": "item",
+      "type": "application/geo+json"
+    },
+    {
+      "href": "./items/Sentinel2L1C.json",
+      "rel": "item",
+      "type": "application/geo+json"
     }
   ]
 }

--- a/examples/items/Landsat8L1G.json
+++ b/examples/items/Landsat8L1G.json
@@ -15,16 +15,15 @@
     "view:off_nadir": 0,
     "view:sun_azimuth": 122.5,
     "view:sun_elevation": 58.1,
-    "pl:collection": "2",
-    "pl:data_type": "L1TP",
+    "landsat:collection_number": "02",
     "pl:item_type": "Landsat8L1G",
     "pl:pixel_resolution": 30,
-    "pl:processed": "2020-09-02T11:20:42Z",
-    "pl:product_id": "LC08_L1TP_219065_20180102_20200902_02_T1",
+    "externalIds": [
+      "LC08_L1TP_219065_20180102_20200902_02_T1"
+    ],
     "pl:quality_category": "standard",
-    "pl:usable_data": 0.686,
-    "pl:wrs_path": 219,
-    "pl:wrs_row": 65,
+    "landsat:wrs_path": 219,
+    "landsat:wrs_row": 65,
     "published": "2022-04-13T20:39:05Z",
     "proj:epsg": null,
     "datetime": "2018-01-02T13:00:06.942405Z"

--- a/examples/items/MOD09GA.json
+++ b/examples/items/MOD09GA.json
@@ -16,15 +16,11 @@
     "view:sun_azimuth": 0,
     "view:sun_elevation": 0,
     "pl:black_fill": 0.07,
-    "pl:data_type": "L2GL",
     "pl:item_type": "MOD09GA",
-    "pl:orbit_direction": "ASC",
+    "sat:orbit_state": "ascending",
     "pl:pixel_resolution": 500,
-    "pl:product_generation_time": "2023-01-09T22:10:57Z",
-    "pl:product_version": "6.0.9",
+    "version": "6.0.9",
     "pl:quality_category": "standard",
-    "pl:sgrid_tile_id": "h10v08",
-    "pl:usable_data": 0.93,
     "published": "2023-01-20T03:10:31Z",
     "proj:epsg": null,
     "datetime": "2023-01-06T11:59:59Z"
@@ -594,7 +590,9 @@
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/version/v1.2.0/schema.json"
   ],
   "collection": "8d2ce872-0007-4a98-80f3-e9b2254d8005: MOD09GA"
 }

--- a/examples/items/MOD09GQ.json
+++ b/examples/items/MOD09GQ.json
@@ -16,15 +16,11 @@
     "view:sun_azimuth": 0,
     "view:sun_elevation": 0,
     "pl:black_fill": 0,
-    "pl:data_type": "L2GL",
     "pl:item_type": "MOD09GQ",
-    "pl:orbit_direction": "ASC",
+    "sat:orbit_state": "ascending",
     "pl:pixel_resolution": 250,
-    "pl:product_generation_time": "2023-01-09T22:12:46Z",
-    "pl:product_version": "6.0.9",
+    "version": "6.0.9",
     "pl:quality_category": "standard",
-    "pl:sgrid_tile_id": "h12v07",
-    "pl:usable_data": 1,
     "published": "2023-01-20T03:11:33Z",
     "proj:epsg": null,
     "datetime": "2023-01-06T11:59:59Z"
@@ -271,7 +267,9 @@
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/version/v1.2.0/schema.json"
   ],
   "collection": "bc2020bb-1333-4a98-9c32-02d9f2d377b3: MOD09GQ"
 }

--- a/examples/items/MYD09GA.json
+++ b/examples/items/MYD09GA.json
@@ -16,15 +16,11 @@
     "view:sun_azimuth": 0,
     "view:sun_elevation": 0,
     "pl:black_fill": 0.07,
-    "pl:data_type": "L2GL",
     "pl:item_type": "MYD09GA",
-    "pl:orbit_direction": "ASC",
+    "sat:orbit_state": "ascending",
     "pl:pixel_resolution": 500,
-    "pl:product_generation_time": "2023-01-11T07:46:41Z",
-    "pl:product_version": "6.0.9",
+    "version": "6.0.9",
     "pl:quality_category": "standard",
-    "pl:sgrid_tile_id": "h23v11",
-    "pl:usable_data": 0.93,
     "published": "2023-01-13T03:42:39Z",
     "proj:epsg": null,
     "datetime": "2023-01-09T11:59:59Z"
@@ -594,7 +590,9 @@
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/version/v1.2.0/schema.json"
   ],
   "collection": "45de5830-6551-4b0b-b8aa-0821374cf562: MYD09GA"
 }

--- a/examples/items/MYD09GQ.json
+++ b/examples/items/MYD09GQ.json
@@ -16,15 +16,11 @@
     "view:sun_azimuth": 0,
     "view:sun_elevation": 0,
     "pl:black_fill": 0,
-    "pl:data_type": "L2GL",
     "pl:item_type": "MYD09GQ",
-    "pl:orbit_direction": "ASC",
+    "sat:orbit_state": "ascending",
     "pl:pixel_resolution": 250,
-    "pl:product_generation_time": "2023-01-11T07:11:40Z",
-    "pl:product_version": "6.0.9",
+    "version": "6.0.9",
     "pl:quality_category": "standard",
-    "pl:sgrid_tile_id": "h29v12",
-    "pl:usable_data": 1,
     "published": "2023-01-13T03:35:26Z",
     "proj:epsg": null,
     "datetime": "2023-01-09T11:59:59Z"
@@ -271,7 +267,9 @@
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/version/v1.2.0/schema.json"
   ],
   "collection": "f113299d-7128-4c37-b7a3-c6556d8f2e5c: MYD09GQ"
 }

--- a/examples/items/Sentinel1.json
+++ b/examples/items/Sentinel1.json
@@ -11,18 +11,15 @@
     "instruments": [
       "SAR-C SAR"
     ],
-    "pl:abs_orbit_number": 46686,
+    "sat:absolute_orbit": 46686,
     "pl:black_fill": 0,
-    "pl:datatake_id": "366731",
     "pl:incidence_far": 46.1482,
     "pl:incidence_near": 30.7401,
     "pl:item_type": "Sentinel1",
-    "pl:orbit_direction": "ASC",
+    "sat:orbit_state": "ascending",
     "pl:pixel_resolution": 10,
-    "pl:polarisation_mode": "dual",
     "pl:quality_category": "standard",
-    "pl:rel_orbit_number": 64,
-    "pl:usable_data": 0,
+    "sat:relative_orbit": 64,
     "published": "2023-01-15T08:24:34Z",
     "proj:epsg": null,
     "sar:frequency_band": "C",
@@ -194,7 +191,8 @@
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/sar/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/sar/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
   ],
   "collection": "2a42f7b8-7c70-445a-a20e-cb19628b8110: Sentinel1"
 }

--- a/examples/items/Sentinel2L1C.json
+++ b/examples/items/Sentinel2L1C.json
@@ -15,20 +15,18 @@
     "view:off_nadir": 7.3,
     "view:sun_azimuth": 124.39,
     "view:sun_elevation": 62.85,
-    "pl:abs_orbit_number": 13225,
+    "sat:absolute_orbit": 13225,
     "pl:black_fill": 0.89,
-    "pl:data_type": "L1C",
-    "pl:datatake_id": "GS2A_20180102T222751_013225_N02.06",
-    "pl:granule_id": "L1C_T01LAL_A013225_20180102T222753",
     "pl:item_type": "Sentinel2L1C",
-    "pl:mgrs_grid_id": "01LAL",
+    "grid:code": "MGRS-01LAL",
     "pl:pixel_resolution": 10,
-    "pl:product_generation_time": "2018-01-02T23:31:09Z",
-    "pl:product_id": "S2A_MSIL1C_20180102T222751_N0206_R072_T01LAL_20180102T233109",
     "pl:quality_category": "standard",
-    "pl:rel_orbit_number": 72,
-    "pl:s2_processor_version": "02.06",
-    "pl:usable_data": 0.11,
+    "sat:relative_orbit": 72,
+    "externalIds": [
+      "S2A_MSIL1C_20180102T222751_N0206_R072_T01LAL_20180102T233109",
+      "L1C_T01LAL_A013225_20180102T222753",
+      "GS2A_20180102T222751_013225_N02.06"
+    ],
     "published": "2019-02-22T12:06:26Z",
     "proj:epsg": null,
     "datetime": "2018-01-02T22:27:53.459000Z"
@@ -796,7 +794,9 @@
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/grid/v1.1.0/schema.json"
   ],
   "collection": "90190d3b-d9b2-4107-bb7d-3c6078bfaaf8: Sentinel2L1C"
 }

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,14 @@ The deprecated item types `PSScene3Band` and `PSScene4Band` are not supported an
   - SkySat:
     - [SkySatCollect Item](examples/items/skysatcollect.json)
     - [SkySatScene Item](examples/items/skysatscene.json)
+  - Others:
+    - [Landsat8L1G Item](examples/items/Landsat8L1G.json)
+    - [MOD09GA Item](examples/items/MOD09GA.json)
+    - [MOD09GQ Item](examples/items/MOD09GQ.json)
+    - [MYD09GA Item](examples/items/MYD09GA.json)
+    - [MYD09GQ Item](examples/items/MYD09GQ.json)
+    - [Sentinel1 Item](examples/items/Sentinel1.json)
+    - [Sentinel2L1C Item](examples/items/Sentinel2L1C.json)
 - [JSON Schema](./schema.json)
 
 ## Item Properties Fields


### PR DESCRIPTION
Fixes #15 (and mostly also #11).

Based on the scheme in #13, removed or replaced all pl:fields that are not defined in the JSON Schema.
If we need them in the metadata, we should add them to the README and JSON Schema.
Some fields can be expressed using other STAC extensions, e.g. sat, version, landsat. Unfornatunately, landsat requires too many fields, to I can't add the schema to the stac_extensions.

Some more comments:
- pl:product_generation_time could be added to the assets
- pl:sgrid_tile_id could be something for the grid extension
- If you need pl:data_type, it needs to be added to the Planet extension
- pl:usable_data we explicitly removed from the STAC extension, so also removed it here
- pl:polarisation_mode sounds like something for the SAC extension
- pl:s2_processor_version could be added via the processing extension, but I'd need the name of the software
- pl:product_id I added as externalIds, which is coming from Records, but has no corresponding STAC extension yet. granule_id and datatake_id could probably also be added there.